### PR TITLE
Version number remains after browser refresh

### DIFF
--- a/src/js/config/urls.js
+++ b/src/js/config/urls.js
@@ -62,7 +62,8 @@ define(['es-ui'], function (app) {
 			updateAcl: '/streams/$$%s'
 		},
 		system:{
-			subsystems: '/sys/subsystems'
+			subsystems: '/sys/subsystems',
+			info: '/info'
 		}
 	});
 });

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -3,13 +3,14 @@ define(['es-ui'], function (app) {
 	'use strict';
 
 	return app.run([
-        '$rootScope', '$state', '$stateParams', 'AuthService',
-        function ($rootScope, $state, $stateParams, authService) {
-
-			// for testing purpose
+        '$rootScope', '$state', '$stateParams', 'AuthService', 'InfoService',
+        function ($rootScope, $state, $stateParams, authService, infoService) {
             authService.existsAndValid()
             .then(function () {
-
+                infoService.getInfo()
+                    .success(function(info){
+                        $rootScope.esVersion = info.esVersion || '0.0.0.0';
+                    });
             }, function () {
                 $rootScope.$currentState = $state.current;
                 $state.go('signin');

--- a/src/js/services/AuthService.js
+++ b/src/js/services/AuthService.js
@@ -10,8 +10,8 @@ define(['./_module'], function (app) {
 		'$cookieStore', 
 		'$http', 
 		'$rootScope',
-		//'baseUrl', // not sure why by this does not work for services
-		function (Base64, $q, $cookieStore, $http, $rootScope) {
+		'urls',
+		function (Base64, $q, $cookieStore, $http, $rootScope, urls) {
 			// initialize to whatever is in the cookie, if anything
 			var authdata = $cookieStore.get('authdata');
 			if(authdata) {
@@ -22,7 +22,6 @@ define(['./_module'], function (app) {
  
 			function setBaseUrl (url) {
 				$rootScope.baseUrl = url;
-				//baseUrl = { url: url };
 			}
 
 			function getBaseUrl () {
@@ -100,7 +99,7 @@ define(['./_module'], function (app) {
 		        	}
 
 		            server = prepareUrl(server);
-		        	return $http.get(server + '/info', {
+		        	return $http.get(server + urls.system.info, {
 		        		headers: {
 		        			'Accept': '*/*',
 		        			Authorization: 'Basic ' + encoded

--- a/src/js/services/InfoService.js
+++ b/src/js/services/InfoService.js
@@ -1,0 +1,14 @@
+/*jshint sub: true*/
+define(['./_module'], function (app) {
+	'use strict';
+	return app.factory('InfoService', ['$http', '$rootScope', 'urls', 'UrlBuilder',
+		function ($http, $rootScope, urls, urlBuilder) {
+		    return {
+		        getInfo: function () {
+		        	var url = urlBuilder.build(urls.system.info);
+                    return $http.get(url);
+		        }
+		    };
+		}
+	]);
+});

--- a/src/js/services/_index.js
+++ b/src/js/services/_index.js
@@ -5,5 +5,6 @@ define([
     './UrlBuilder',
     './SprintfService',
     './AuthService',
+    './InfoService',
     './MessageService'
 ], function () {});


### PR DESCRIPTION
- Added info endpoint to urls
- Added InfoService to get the info
- Added InfoService to run.js to get the version number on refresh
# fixes issue #28
