### PR TITLE
Check if the stream id exists before we add it to the list of streams.

### DIFF
--- a/src/js/modules/streams/controllers/StreamsListCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsListCtrl.js
@@ -10,8 +10,10 @@ define(['./_module'], function (app) {
 				var filtered = {}, i = 0, length = entries.length, item, result = [];
 
 				for(; i<length; i++) {
-					item = entries[i];
-					filtered[item.streamId] = true;
+					if(entries[i].streamId){
+						item = entries[i];
+						filtered[item.streamId] = true;
+					}
 				}
 
 				for (item in filtered) {


### PR DESCRIPTION
When filtering out the streams from the list of created streams, don't add it, if the stream id does not exist.
fixes https://github.com/EventStore/EventStore/issues/399
