### PR TITLE
Fix projections page

### DIFF
--- a/src/js/modules/projections/controllers/ProjectionsListCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsListCtrl.js
@@ -8,7 +8,8 @@ define(['./_module'], function (app) {
 
 			var all = pollerProvider.create({
 				interval: 2000,
-				action: projectionsService.all
+				action: projectionsService.all,
+				params: [ false ]
 			});
 
 			all.start();


### PR DESCRIPTION
The poller is not created correctly and errors on the first poll. This results in the projections page always being blank.