### PR TITLE
Improvements to the debugging experience

### DIFF
--- a/src/js/config/urls.js
+++ b/src/js/config/urls.js
@@ -26,7 +26,8 @@ define(['es-ui'], function (app) {
 			state: '%s/state', // $s - query url
 			commands: {
 				enable: '%s/command/enable', // $s - query url
-				disable: '%s/command/disable' // $s - query url
+				disable: '%s/command/disable', // $s - query url
+				reset: '%s/command/reset' // $s - query url
 			}
 		},
 		projections: {

--- a/src/js/modules/projections/controllers/QueryCtrl.js
+++ b/src/js/modules/projections/controllers/QueryCtrl.js
@@ -123,12 +123,19 @@ define(['./_module'], function (app) {
 				});
 			};
 
+
 			$scope.debug = function () {
-				$state.go('projections.item.debug', { 
-					location: encodeURIComponent(location) 
-				}, { 
-					inherit: false 
-				});
+				queryService.disable(location)
+                .then(function onQueryDisabled(){
+                    queryService.reset(location)
+                    .then(function onQueryReset(){
+                        $state.go('projections.item.debug', {
+                            location: encodeURIComponent(location)
+                        }, { 
+                            inherit: false 
+                        });
+                    })
+                });
 			};
 
 			var unbindHandler = $scope.$watch('query', function(scope, newValue, oldValue) {

--- a/src/js/modules/projections/services/QueryService.js
+++ b/src/js/modules/projections/services/QueryService.js
@@ -36,6 +36,12 @@ define(['./_module'], function (app) {
 
 						return $http.post(url);
 					},
+					reset: function (url) {
+						url = urlBuilder.simpleBuild(urls.query.commands.reset, 
+							url);
+
+						return $http.post(url);
+					},
 				};
 			}
 		];


### PR DESCRIPTION
Fixes #76
- Disables and Resets the query ready for the debugging session to commence. 
- Read the information (state, stats, etc) from the projection before enabling (this gets
  rid of some projections (transient) that run until completion and no
longer produce a position which the UI uses to read events
- When there are no further events for the projection to process, set
  running status as true (i.e. the projection is not being paused for
debugging)
- When we update the projection, we disable it to stop it from updating
  and running to completion, we will enable it when the debugging
session has reloaded