### PR TITLE
Change subscription details to /info

### DIFF
--- a/src/js/config/urls.js
+++ b/src/js/config/urls.js
@@ -70,7 +70,7 @@ define(['es-ui'], function (app) {
 		},
 		competing:{
 			subscriptions: '/subscriptions',
-			subscriptionDetails: '/subscriptions/%s/%s',
+			subscriptionDetails: '/subscriptions/%s/%s/info',
 			create: '/subscriptions/%s/%s',
 			update: '/subscriptions/%s/%s',
 			delete: '/subscriptions/%s/%s'


### PR DESCRIPTION
Change the endpoint (add /info) in getting the details for a subscription.

Dependent on https://github.com/EventStore/EventStore/pull/737