### PR TITLE
Updated colours and site header styles

### DIFF
--- a/src/scss/_module-siteheader.scss
+++ b/src/scss/_module-siteheader.scss
@@ -13,12 +13,7 @@
 	        justify-content: space-between;
 	padding: 0 3rem;
 	background: $green;
-	background-image: linear-gradient(45deg, transparentize($green, 0.5) 0%, transparentize($green, 0.5) 50%, transparentize($green-dark, 0.5) 50%, transparentize($green-dark, 0.5) 100%),
-		linear-gradient(135deg, transparentize($green, 0.5) 0%, transparentize($green, 0.5) 50%, transparentize($green-dark, 0.5) 50%, transparentize($green-dark, 0.5) 100%);
 	font-weight: 700;
-	@media screen and (max-width: 1270px), screen and (max-device-width: 1270px) {
-		background-image: linear-gradient(90deg, $green 0%, $green-dark 100%);
-	}
 }
 
 .site-title {
@@ -53,7 +48,7 @@
 		text-decoration: none;
 		border-radius: 0.25rem;
 		&:focus, &:hover {
-			background: $green;
+			background: $green-dark;
 			color: $white-off;
 		}
 	}
@@ -62,10 +57,10 @@
 .site-nav__item--active {
 	@extend .site-nav__item;
 	a {
-		background: $green;
+		background: $green-dark;
 		color: $white;
 		&:focus, &:hover {
-			background: $green;
+			background: $green-dark;
 			color: $white;
 		}
 	}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,9 +1,9 @@
 // Variables
 
-$black:	       #424440;
+$black:	       #435261;
 $blue:         #009CDB;
-$green:        #6BA300;
-$green-dark:   darken($green, 5%);
+$green:        #5AB552;
+$green-dark:   #2E9625;
 $grey:         #727470;
 $grey-dark:    #525450;
 $grey-light:   #E2E4E0;


### PR DESCRIPTION
- Updated green, dark green and black values to match latest style
guide.
- Removed site header gradient to improve rendering for low colour
depth (e.g. remote desktop users).

**I haven’t compiled Sass to CSS. This process will need adding to the packaging script.**