### PR TITLE
Add startsWith polyfil for backwards compatibility

### DIFF
--- a/src/js/modules/competing/services/SubscriptionsMapper.js
+++ b/src/js/modules/competing/services/SubscriptionsMapper.js
@@ -3,6 +3,12 @@ define(['./_module'], function (app) {
 	'use strict';
 
 	return app.provider('SubscriptionsMapper', function () {
+		if (!String.prototype.startsWith) {
+		  String.prototype.startsWith = function(searchString, position) {
+		    position = position || 0;
+		    return this.indexOf(searchString, position) === position;
+		  };
+		}
 		function createEmptyGroup (groupName) {
 			return {
                 streamName: groupName,


### PR DESCRIPTION
This was picked up in Event Store List (https://groups.google.com/forum/#!searchin/event-store/competing$20consumers$20ui/event-store/9r3uffAZZNE/4m2tsrOPCQAJ).

Internet Explorer doesn't have `startsWith` implemented which is used in the competing consumers` subscription mapper.

More details here regarding compatibility of `startsWith` can be found here. https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Browser_compatibility