### PR TITLE
Redirect the user if they try to access projections when they're disabled

### DIFF
--- a/src/js/modules/projections/controllers/ProjectionsListCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsListCtrl.js
@@ -3,9 +3,14 @@ define(['./_module'], function (app) {
     'use strict';
 
     return app.controller('ProjectionsListCtrl', [
-		'$scope', 'ProjectionsService', 'ProjectionsMapper', 'poller', 'MessageService',
-		function ($scope, projectionsService, projectionsMapper, pollerProvider, msg) {
+		'$rootScope', '$scope', 'ProjectionsService', 'ProjectionsMapper', 'poller', 'MessageService', '$state',
+		function ($rootScope, $scope, projectionsService, projectionsMapper, pollerProvider, msg, $state) {
 
+            if(!$rootScope.projectionsAllowed) {
+                msg.failure('Projections are not enabled on the node');
+                $state.go('dashboard.list');
+            }
+            
 			var all = pollerProvider.create({
 				interval: 2000,
 				action: projectionsService.all,


### PR DESCRIPTION
Warn and redirect the user if they try to access projections while they are disabled

If projections are not enabled on the node and the user tries to go to the /projections route,
they will now see an error message telling them projections aren't enabled and will be redirected to the dashboard.