### PR TITLE
The partition method expects the isJson as the second parameter

### DIFF
--- a/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
@@ -152,6 +152,7 @@ define(['./_module'], function (app) {
 		        if (definition.byCustomPartitions) {
 		            partition = processor.get_state_partition(
                             currentEvent.isJson ? angular.toJson(currentEvent.data) : currentEvent.data,
+                            currentEvent.isJson,
                             currentEvent.eventStreamId,
                             currentEvent.eventType,
                             currentEvent.category,


### PR DESCRIPTION
Partially fixes https://github.com/EventStore/EventStore/issues/845