### PR TITLE
Show errors thrown when a chunk has been scavenged

### DIFF
--- a/src/js/modules/admin/controllers/ScavengeCtrl.js
+++ b/src/js/modules/admin/controllers/ScavengeCtrl.js
@@ -86,6 +86,9 @@ define(['./_module'], function (app) {
                                 var chunksScavenged = chunkData.chunkEndNumber - chunkData.chunkStartNumber + 1;
                                 result = chunksScavenged + ' chunk(s) scavenged';
                             }
+                            if (chunkData.errorMessage) {
+                                result = 'Error: ' + chunkData.errorMessage;
+                            }
                             info.push({
                                 status: 'Scavenging chunks ' + chunkData.chunkStartNumber + ' - ' +
                                             chunkData.chunkEndNumber + ' complete',


### PR DESCRIPTION
Part of PR https://github.com/EventStore/EventStore/pull/1023

Shows any error messages that are on the `ScavengeChunkCompleted` events as part of the results on the scavenges page.