### PR TITLE
Added math round to approx speed calculation

### DIFF
--- a/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
+++ b/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
@@ -80,7 +80,7 @@ define(['./_module'], function (app) {
                     }
                     var seconds = (new Date().getTime() - replica.catchupStartTime) / constants.clusterStatus.replicaPollInterval;
                     var bytes = replica.totalBytesSent - replica.catchupStartBytesSent;
-                    replica.approxSpeed = bytes / seconds;
+                    replica.approxSpeed = Math.round(bytes / seconds);
                     var estimatedTime = Math.round(replica.bytesToCatchUp / replica.approxSpeed);
                     if(estimatedTime < 1) {
                         estimatedTime = 1;


### PR DESCRIPTION
Makes it easier to read the transfer speed value. Since it is an approximation, the decimal point is not really needed and only makes it harder to understand.