### PR TITLE
Remove the default tracking of emitted streams

### DIFF
--- a/src/js/modules/projections/controllers/ProjectionsNewCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsNewCtrl.js
@@ -58,16 +58,6 @@ define(['./_module'], function (app) {
 					});
 			};
 
-			var unbindEmitHandler = $scope.$watch('emit', function (newVal, oldVal) {
-				if(newVal == true){
-					$scope.trackemittedstreams = true;
-					$scope.trackEmittedStreamsDisabled = false;
-				} else {
-					$scope.trackEmittedStreamsDisabled = true;
-					$scope.trackemittedstreams = false;
-				}
-			});
-
 			var unbindModeHandler = $scope.$watch('mode', function (newVal, oldVal) {
 				var isContinuous;
 				if(newVal !== oldVal) {
@@ -84,7 +74,6 @@ define(['./_module'], function (app) {
 			});
 			
 			$scope.$on('$destroy', function () {
-				unbindEmitHandler();
 				unbindModeHandler();
 			});
 		}


### PR DESCRIPTION
The option track emitted streams doesn't need to be enabled by default as it's main purpose is to provide the user with the ability to delete all of the streams that the projection wrote to during it's existence. 

Due to this is option being enabled by default when `emit` is checked, users aren't giving this option a second thought and therefor leaving it enabled.

This will also then reflect the default for when projections are created through the HTTP API which has this (`trackemittedstreams`) value set to `false` by default.