### PR TITLE
While query is running, refresh/hide state.

### DIFF
--- a/src/js/modules/projections/controllers/QueryCtrl.js
+++ b/src/js/modules/projections/controllers/QueryCtrl.js
@@ -39,6 +39,8 @@ define(['./_module'], function (app) {
 
 			function monitorState () {
 
+				$scope.state = undefined;
+
 				monitor.stop();
 				monitor.start(location, {
 					ignoreQuery: true,

--- a/src/js/modules/projections/templates/templates.js
+++ b/src/js/modules/projections/templates/templates.js
@@ -138,7 +138,7 @@ try {
 }
 module.run(['$templateCache', function($templateCache) {
   $templateCache.put('query.tpl.html',
-    '<header class=page-header><h2 class=page-title>Query</h2><ul class=page-nav><li class=page-nav__item><button ng-click=run()>Run</button></li><li class=page-nav__item><button ng-click=stop() ng-disabled=disableStop()>Break</button></li><li class=page-nav__item><button ng-click=debug() ng-disabled=!isCreated>Debug</button></li></ul></header><h3 ng-visible=status>{{status}}<br></h3><i>{{stateReason}}</i><div class=container><div class=container-left><h3 class=block-title>Source</h3><div ui-ace=aceConfig ng-model=query></div></div><div class=container-right><h3 class=block-title>State</h3><pre>\n' +
+    '<header class=page-header><h2 class=page-title>Query</h2><ul class=page-nav><li class=page-nav__item><button ng-click=run()>Run</button></li><li class=page-nav__item><button ng-click=stop() ng-disabled=disableStop()>Break</button></li><li class=page-nav__item><button ng-click=debug() ng-disabled=!isCreated>Debug</button></li></ul></header><h3 ng-visible=status>{{status}}<br></h3><i>{{stateReason}}</i><div class=container><div class=container-left><h3 class=block-title>Source</h3><div ui-ace=aceConfig ng-model=query></div></div><div class=container-right><h3 class=block-title>State</h3><pre ng-if="state !== undefined && isStopped">\n' +
     '{{state | json}}\n' +
     '		</pre></div></div>');
 }]);

--- a/src/js/modules/projections/views/query.tpl.html
+++ b/src/js/modules/projections/views/query.tpl.html
@@ -27,7 +27,7 @@
 			</div>
 			<div class="container-right">
 				<h3 class="block-title">State</h3>
-		<pre>
+		<pre ng-visible="state !== undefined && isStopped">
 {{state | json}}
 		</pre>
 			</div>

--- a/src/js/modules/projections/views/query.tpl.html
+++ b/src/js/modules/projections/views/query.tpl.html
@@ -27,7 +27,7 @@
 			</div>
 			<div class="container-right">
 				<h3 class="block-title">State</h3>
-		<pre ng-visible="state !== undefined && isStopped">
+		<pre ng-if="state !== undefined && isStopped">
 {{state | json}}
 		</pre>
 			</div>


### PR DESCRIPTION
Fairly frequently I run a query, get some results, tweak it and run it
again. Since state doesn't clear between runs it can easily get
confusing whether the second result is actually something new or the
first query's results lingering.