### PR TITLE
Remember the last query in local storage unless overrides are specified.

### DIFF
--- a/src/js/modules/projections/controllers/QueryCtrl.js
+++ b/src/js/modules/projections/controllers/QueryCtrl.js
@@ -17,6 +17,8 @@ define(['./_module'], function (app) {
                 });
 			} else if ($stateParams.initStreamId) {
                           $scope.query = "fromStream('" + $stateParams.initStreamId + "')\n  .when({\n  })";
+                        } else {
+                          $scope.query = queryService.retrieveQuery();
                         }
 
 			function create () {
@@ -108,7 +110,10 @@ define(['./_module'], function (app) {
 				mode: 'javascript',
 				useWrapMode: false,
 				showGutter: true,
-				theme: 'monokai'
+				theme: 'monokai',
+                                onChange: function () {
+                                  queryService.rememberQuery($scope.query);
+                                }
 			};
 
 			$scope.disableStop = function () {

--- a/src/js/modules/projections/services/QueryService.js
+++ b/src/js/modules/projections/services/QueryService.js
@@ -9,6 +9,16 @@ define(['./_module'], function (app) {
 			function ($http, $q, urls, urlBuilder, uriProvider) {
 
 				return {
+                                        rememberQuery: function (query) {
+						if (!localStorage) { return; }
+
+						localStorage.setItem('latest-query', query);
+                                        },
+                                        retrieveQuery: function () {
+						if (!localStorage) { return ''; }
+
+						return localStorage.getItem('latest-query') || '';
+                                        },
 					create: function (source, params) {
 						var qp = uriProvider.getQuery(params),
 							url = urlBuilder.build(urls.query.create) + qp;


### PR DESCRIPTION
I find myself clearing the query accidentally, fairly regularly.

This PR is probably the "dumbest thing possible" for remembering the last query (it's in local storage so it's only saved in one browser at a time).

Here's what it looks like
![simple-query-memory](https://user-images.githubusercontent.com/1709849/29898265-d56c7290-8db2-11e7-99c0-368edbee1f61.gif)

What are your thoughts?

This seems like (potentially) a different solution to #151, however, doing it for projections is not as simple as for query (there's only really 1 query at a time being modified).