### PR TITLE
Remove activity column from dashboard and snapshot.

### DIFF
--- a/src/js/modules/dashboard/controllers/DashboardSnapshotCtrl.js
+++ b/src/js/modules/dashboard/controllers/DashboardSnapshotCtrl.js
@@ -24,7 +24,7 @@ define(['./_module'], function (app) {
 						item.lengthLifetimePeak,
 						item.avgItemsPerSecond,
 						item.avgProcessingTime.toFixed(3),
-						item.busy,
+						Math.max(0, Math.min(100, 100 - item.idleTimePercent)).toFixed(1),
 						item.totalItemsProcessed,
 						item.inProgressMessage + ' / ' + item.lastProcessedMessage
 					);

--- a/src/js/modules/dashboard/services/DashboardMapper.js
+++ b/src/js/modules/dashboard/services/DashboardMapper.js
@@ -16,6 +16,7 @@ define(['./_module'], function (app) {
                 lengthLifetimePeak: 0,
                 totalItemsProcessed: 0,
                 groupQueues: 0,
+                busy: 0,
                 queues: []
 			};
 		}
@@ -30,7 +31,9 @@ define(['./_module'], function (app) {
 
 	        for(prop in data.es.queue) {
 	            current = data.es.queue[prop];
-	            
+
+                    current.busy = Math.max(0, Math.min(100, 100 - current.idleTimePercent));
+
 	            if(current.groupName) {
 	                
 	                if(!result[current.groupName]) {

--- a/src/js/modules/dashboard/templates/templates.js
+++ b/src/js/modules/dashboard/templates/templates.js
@@ -18,7 +18,7 @@ try {
 }
 module.run(['$templateCache', function($templateCache) {
   $templateCache.put('dashboard.row.header.tpl.html',
-    '<td ng-if=esQueue.show>{{ esQueue.queueName }} <a class=table-collapsetoggle>&minus;</a></td><td ng-if=!esQueue.show>{{ esQueue.queueName }} <a class=table-collapsetoggle>&plus;</a></td><td>{{ esQueue.lengthCurrentTryPeak }}</td><td>{{ esQueue.lengthLifetimePeak }}</td><td>{{ esQueue.avgItemsPerSecond }}</td><td>{{ esQueue.avgProcessingTime.toFixed(3)}}</td><td>{{ esQueue.busy }}</td><td>{{ esQueue.totalItemsProcessed }}</td><td style="text-align: right">n/a</td>');
+    '<td ng-if=esQueue.show>{{ esQueue.queueName }} <a class=table-collapsetoggle>&minus;</a></td><td ng-if=!esQueue.show>{{ esQueue.queueName }} <a class=table-collapsetoggle>&plus;</a></td><td>{{ esQueue.lengthCurrentTryPeak }}</td><td>{{ esQueue.lengthLifetimePeak }}</td><td>{{ esQueue.avgItemsPerSecond }}</td><td>{{ esQueue.avgProcessingTime.toFixed(3)}}</td><td></td><td>{{ esQueue.totalItemsProcessed }}</td><td style="text-align: right">n/a</td>');
 }]);
 })();
 
@@ -30,7 +30,7 @@ try {
 }
 module.run(['$templateCache', function($templateCache) {
   $templateCache.put('dashboard.row.tpl.html',
-    '<td>{{ esQueue.queueName }}</td><td>{{ esQueue.lengthCurrentTryPeak }}</td><td>{{ esQueue.lengthLifetimePeak }}</td><td>{{ esQueue.avgItemsPerSecond }}</td><td>{{ esQueue.avgProcessingTime.toFixed(3)}}</td><td>{{ esQueue.busy }}</td><td>{{ esQueue.totalItemsProcessed }}</td><td style="text-align: right">{{ esQueue.inProgressMessage }} / {{ esQueue.lastProcessedMessage }}</td>');
+    '<td>{{ esQueue.queueName }}</td><td>{{ esQueue.lengthCurrentTryPeak }}</td><td>{{ esQueue.lengthLifetimePeak }}</td><td>{{ esQueue.avgItemsPerSecond }}</td><td>{{ esQueue.avgProcessingTime.toFixed(3)}}</td><td>{{ esQueue.busy | number: 1 }}%</td><td>{{ esQueue.totalItemsProcessed }}</td><td style="text-align: right">{{ esQueue.inProgressMessage }} / {{ esQueue.lastProcessedMessage }}</td>');
 }]);
 })();
 

--- a/src/js/modules/dashboard/views/dashboard.row.header.tpl.html
+++ b/src/js/modules/dashboard/views/dashboard.row.header.tpl.html
@@ -10,7 +10,7 @@
 
 <td >{{ esQueue.avgItemsPerSecond }}</td>
 <td >{{ esQueue.avgProcessingTime.toFixed(3)}} </td>
-<td >{{ esQueue.busy }} </td>
+<td ></td>
 
 <td >{{ esQueue.totalItemsProcessed }}</td>
 <td  style="text-align: right">n/a</td>

--- a/src/js/modules/dashboard/views/dashboard.row.tpl.html
+++ b/src/js/modules/dashboard/views/dashboard.row.tpl.html
@@ -6,7 +6,7 @@
 
 <td>{{ esQueue.avgItemsPerSecond }}</td>
 <td>{{ esQueue.avgProcessingTime.toFixed(3)}} </td>
-<td>{{ esQueue.busy }} </td>
+<td>{{ esQueue.busy | number: 1 }}% </td>
 
 <td>{{ esQueue.totalItemsProcessed }}</td>
 


### PR DESCRIPTION
I'm not really sure if this is the right thing to do so this is really
more of a "conversation starter" than anything else.

I noticed the `Activity` column reaches into the `.busy` property which
I have never seen come back and causes the snapshot to have a column of
all `undefined` values. Of course, just because I've never seen it doesn't mean
it is not a real thing.

**Dashboard activity column before this change**
![blank-activity](https://user-images.githubusercontent.com/1709849/30687233-afda6d70-9e88-11e7-829f-a827d43b6648.png)

**Snapshot activity column before this change**
![undefined-activity](https://user-images.githubusercontent.com/1709849/30687258-bf2e98dc-9e88-11e7-929f-462f2a32c196.png)

**Dashboard after this change**
![dashboard-wo-activity](https://user-images.githubusercontent.com/1709849/30687277-cb5c6b0c-9e88-11e7-92ea-bbf13a97a585.png)

**Snapshot after this change**
![snapshot-wo-activity](https://user-images.githubusercontent.com/1709849/30687293-d2caa958-9e88-11e7-844a-3f3d5204c292.png)


Is there something I'm missing here?