### PR TITLE
Projection debugging: State was not being updated when processing last event

### DIFF
--- a/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
@@ -232,7 +232,9 @@ define(['./_module'], function (app) {
                     currentEvent.isJson ? JSON.stringify(currentEvent.metadata) : currentEvent.metadata,
                     partition);
 
-		        cachedStates[partition] = state;
+				cachedStates[partition] = state;
+				stateLoaded(cachedStates[partition]);
+
 		        currentPosition = currentEvent.readerPosition;
 		        loadEvents();
 		    };


### PR DESCRIPTION
Reproduction steps:

1. Create a projection reading from a stream `test`:
```
fromStream('test')
.when({
   "$any":function(s,e){
       s.state = JSON.stringify(e);
   } 
});
```
2. Write a few events to `test`
3. Debug the projection
4. Click on Run Step until the last event is processed: the state is updated for all events except the last one

That's because the state was being shown only based on the current event's partition - when no new event is loaded (after processing the last event), the state was staying the same instead of showing the last event's state.
