### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
   "immed": true,
   "latedef": "nofunc",
   "plusplus": false,
-  "newcap": true,
+  "newcap": false,
   "noarg": true,
   "quotmark": "single",
   "regexp": true,
@@ -22,6 +22,7 @@
     "angular": false,
     "define": false,
     "alert": false,
-    "confirm": false
+    "confirm": false,
+    "self": false
   }
 }

--- a/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemDebugCtrl.js
@@ -242,7 +242,7 @@ define(['./_module'], function (app) {
 
 		    $scope.update = function () {
                 $scope.isUpdating = true;
-		        projectionsService.updateQuery($scope.location, $scope.query)
+		        projectionsService.updateQuery($scope.location, null, $scope.query)
 				.success(function () {
 				    msg.info('Projection Updated');
                     $window.location.reload();

--- a/src/js/modules/projections/services/ProjectionsService.js
+++ b/src/js/modules/projections/services/ProjectionsService.js
@@ -186,10 +186,9 @@ define(['./_module'], function (app) {
 					},
 					updateQuery: function (url, emit, source) {
 
-						if(source) {
+						if(emit) {
 							url = urlBuilder.simpleBuild(urls.projections.updateQuery, url) + emit;
 						} else {
-							source = emit;
 							url = urlBuilder.simpleBuild(urls.projections.updatePlainQuery, url);
 						}
 


### PR DESCRIPTION
- Relax jshint rules
- Fix bug in projectionsService.updateQuery call: An empty string source ("") would cause the `source` variable to be assigned to the `emit` value ('yes' or 'no')