### PR TITLE
Remove certain admin requirements from header

### DIFF
--- a/src/views/index.tpl.html
+++ b/src/views/index.tpl.html
@@ -16,13 +16,13 @@
 				<a ui-sref="streams.list">Stream Browser</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('projections') }" title="{{!isAdmin ? notAdminMessage : !projectionsAllowed ? projectionsNotRunningMessage : ''}}">
-				<a ng-class="{'disabled': !projectionsAllowed || !isAdmin}" ui-sref="projections.list">Projections</a>
+				<a ng-class="{'disabled': !projectionsAllowed}" ui-sref="projections.list">Projections</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('query') }" title="{{!projectionsAllowed ? projectionsNotRunningMessage : ''}}">
 				<a ng-class="{'disabled':!projectionsAllowed}" ui-sref="query">Query</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('competing') }" title="{{!isAdmin ? notAdminMessage : ''}}">
-				<a ng-class="{'disabled': !isAdmin}" ui-sref="subscriptions.list">Persistent Subscriptions</a>
+				<a ui-sref="subscriptions.list">Persistent Subscriptions</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('admin') }" title="{{!isAdmin ? notAdminMessage : ''}}">
 				<a ng-class="{'disabled': !isAdmin}" ui-sref="admin">Admin</a>


### PR DESCRIPTION
Both the "Projections" and "Persistent Subscriptions" links are currently disabled in the UI if you are not logged in as admin.
However, these screens can be accessed by simply suffixing the UI URL with `/projections` or `/subscriptions` and the user can then see the data. This is because the endpoints belonging to these screens are public and don't need authentication at all (notice lack of `-u` flag):

```
$ curl -XGET -I http://127.0.0.1:2113/projections/any
HTTP/1.1 200 OK
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Headers: Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTos
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Location, ES-Position, ES-CurrentVersion
Cache-Control: max-age=0, no-cache, must-revalidate
Vary: Accept
Content-Type: application/json; charset=utf-8
Server: Mono-HTTPAPI/1.0
Date: Tue, 23 Apr 2019 11:35:55 GMT
Content-Length: 78027
Keep-Alive: timeout=15,max=100

$ curl -XGET -I http://127.0.0.1:2113/subscriptions
HTTP/1.1 200 OK
Access-Control-Allow-Methods: GET, OPTIONS
Access-Control-Allow-Headers: Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTos
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Location, ES-Position, ES-CurrentVersion
Content-Type: application/json; charset=utf-8
Server: Mono-HTTPAPI/1.0
Date: Tue, 23 Apr 2019 11:36:00 GMT
Content-Length: 16096
Keep-Alive: timeout=15,max=100
```