### PR TITLE
Fix for UI not being able to query # in stream names

### DIFF
--- a/src/js/services/UrlBuilder.js
+++ b/src/js/services/UrlBuilder.js
@@ -25,9 +25,7 @@ define(['./_module', 'angular'], function (app, angular) {
 
 					//Double encode if '#' present in URL
 					if(url.indexOf("%23")>-1){
-
 						url=url.replace(/%23/g,'%2523');
-
 					}
 
 					return $rootScope.baseUrl + url;

--- a/src/js/services/UrlBuilder.js
+++ b/src/js/services/UrlBuilder.js
@@ -23,6 +23,13 @@ define(['./_module', 'angular'], function (app, angular) {
 
 					url = print.format.apply(null, params);
 
+					//Double encode if '#' present in URL
+					if(url.indexOf("%23")>-1){
+
+						url=url.replace(/%23/g,'%2523');
+
+					}
+
 					return $rootScope.baseUrl + url;
 				}
 			};


### PR DESCRIPTION
## UI fix for queries on stream containing `#` in their names returning 404
![image](https://user-images.githubusercontent.com/20010676/61770477-63d96200-adfe-11e9-8d6d-c57065c37b24.png)


Related RFC for Uniform Resource Identifier (URI): Generic Syntax :  https://tools.ietf.org/html/rfc3986

- [x]  Works with `#` being present at any position in stream name

⚠ Fix only for UI, other clients consuming the HTTP API of EventStore may still face 404 when querying streams with `#`

fixes : #188 