### PR TITLE
Added to support pinned by correlation PS consumer strategy in ES Core

### DIFF
--- a/src/js/modules/competing/controllers/SubscriptionsNewCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsNewCtrl.js
@@ -15,6 +15,9 @@ define(['./_module'], function (app) {
 			}, {
 				value: 'Pinned',
 				name: 'Pinned'
+			}, {
+				value: 'PinnedByCorrelation',
+				name: 'Pinned By Correlation'
 			}];
 
             setDefaults();


### PR DESCRIPTION
This is to support the my recent pull request in ES core. 
This will add pinned by correlation dropdown option to PS consumer screen