### PR TITLE
View scavenge by id on admin ui using slash instead of dash

### DIFF
--- a/src/js/modules/admin/services/AdminService.js
+++ b/src/js/modules/admin/services/AdminService.js
@@ -33,7 +33,7 @@ define(['./_module'], function (app) {
                     	return $http.get(url);
                     },
                     scavengeInfo: function(scavengeId, fromEvent, pageSize) {
-                    	var url = urlBuilder.build(urls.streams.scavenges + '-' + scavengeId + '/' + fromEvent + '/' + pageSize + '?embed=tryharder');
+                    	var url = urlBuilder.build(urls.streams.scavenges + '/' + scavengeId + '/' + fromEvent + '/' + pageSize + '?embed=tryharder');
                     	return $http.get(url);
                     },
                     lastScavengeStatus: function() {


### PR DESCRIPTION
In relation to https://github.com/EventStore/EventStore/issues/2305 and https://github.com/EventStore/EventStore/pull/2310