### PR TITLE
Introduce release process for the UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+on:
+  push:
+    tags:
+      - "oss-v*"
+jobs:
+  package:
+    name: Package OSS UI
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF:22}
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - name: Lookup or create release
+        uses: EventStore/Automations/lookup-or-create-release@master
+        id: release
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          build-type: release
+          version: oss-v${{ steps.get_version.outputs.version }}
+      - name: Packaging
+        run: |
+          sudo npm install bower@~1.8.4 -g
+          sudo bower install --allow-root
+          sudo npm install gulp@~3.8.8 -g
+          npm install
+          gulp dist
+          mv es-dist clusternode-web
+          zip -r EventStore.OSS.UI-v${{ steps.get_version.outputs.version}}.zip clusternode-web
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        with:
+           upload_url: ${{ steps.release.outputs.upload_url }}
+           asset_path: ./EventStore.OSS.UI-v${{ steps.get_version.outputs.version}}.zip
+           asset_name: EventStore.OSS.UI-v${{ steps.get_version.outputs.version}}.zip
+           asset_content_type: application/zip


### PR DESCRIPTION
Fixes #11

Introducing this pipeline provides us with the ability to push up a tag and produce an asset for the OSS UI.

Steps:

 Push up a tag in the form of oss-v{version}.
 The release process will be kicked off and will build the OSS-UI and upload the asset to the release.