### PR TITLE
Align release asset names in nightly releases to reflect normal release names

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
           npm install
           gulp dist
           mv es-dist clusternode-web
-          zip -r EventStore.UI-v${{ steps.release.outputs.version}}.zip clusternode-web
+          zip -r EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip clusternode-web
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -35,6 +35,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         with:
            upload_url: ${{ steps.release.outputs.upload_url }}
-           asset_path: ./EventStore.UI-v${{ steps.release.outputs.version}}.zip
-           asset_name: EventStore.UI-v${{ steps.release.outputs.version}}.zip
+           asset_path: ./EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip
+           asset_name: EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip
            asset_content_type: application/zip


### PR DESCRIPTION
Instead of `EventStore.UI-v${{ version}}` we will now use `EventStore.OSS.UI-v${{ version}}`
REF: https://github.com/EventStore/EventStore.UI/blob/master/.github/workflows/release.yml#L44