### PR TITLE
Change version extraction from 22 to 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF:22}
+        run: echo ::set-output name=version::${GITHUB_REF:15}
       - name: Setup node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
We want to tag versions with `oss-v20.6.0` and pull out `20.6.0` as the version.