### PR TITLE
Support multiple authentication flows

### DIFF
--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -23,37 +23,31 @@ define(['./_module'], function (app) {
 				}
 
 				authService.validate($scope.log.username, $scope.log.password, $scope.log.server)
-				.success(function (info) {
-					$rootScope.singleNode = true;
-					$rootScope.esVersion = info.esVersion || '0.0.0.0';
-                    $rootScope.esVersion = $rootScope.esVersion  === '0.0.0.0' ? 'development build' : $rootScope.esVersion;
-                    $rootScope.projectionsEnabled = info.features.projections === true;
-                    $rootScope.userManagementEnabled = info.features.userManagement === true;
-                    $rootScope.streamsBrowserEnabled = info.features.atomPub === true;
-
+				.success(function () {
                     authService.getUserGroups($scope.log.username).then(function(groups) {
 						authService.setCredentials($scope.log.username, $scope.log.password, $scope.log.server, groups);
-						if($rootScope.isAdminOrOps) {
-	                    	scavengeNotificationService.start();
-		                    infoService.getOptions().then(function onGetOptions(response){
-		                        var options = response.data;
-		                        for (var index in options) {
-		                            if(options[index].name === 'ClusterSize' && options[index].value > 1){
-		                                $rootScope.singleNode = false;
-		                            }
-		                        }
-								redirectAfterLoggingIn();
-		                    });
-	                	} else {
-	                		redirectAfterLoggingIn();
-	                	}
+						setSingleNodeOrCluster();
+	                	redirectAfterLoggingIn();
                     });
 				})
 				.error(function () {
-					msg.warn('Server does not exist or incorrect user credentials supplied.');
+					msg.warn('Incorrect user credentials supplied.');
 				});
 			};
 
+			function setSingleNodeOrCluster(){
+                if($rootScope.isAdminOrOps) {
+                    scavengeNotificationService.start();
+                    infoService.getOptions().then(function onGetOptions(response){
+                        var options = response.data;
+                        for (var index in options) {
+                            if(options[index].name === 'ClusterSize' && options[index].value > 1){
+                                $rootScope.singleNode = false;
+                            }
+                        }
+                    });
+                }
+            }
 
 			function redirectAfterLoggingIn() {
 				if($rootScope.previousUrl && $rootScope.previousUrl !== '/'){

--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -8,13 +8,9 @@ define(['./_module'], function (app) {
 
 			$scope.log = {
 				username: '',
-				password: '',
-				server: $location.protocol() + '://' + $location.host() + ':' + $location.port()
+				password: ''
 			};
 
-			if(!$location.host()) {
-				$scope.log.server = 'https://127.0.0.1:2113';
-			}
 
 			$scope.signIn = function () {
 				if ($scope.login.$invalid) {
@@ -22,10 +18,10 @@ define(['./_module'], function (app) {
 					return;
 				}
 
-				authService.validate($scope.log.username, $scope.log.password, $scope.log.server)
+				authService.validate($scope.log.username, $scope.log.password)
 				.success(function () {
                     authService.getUserGroups($scope.log.username).then(function(groups) {
-						authService.setCredentials($scope.log.username, $scope.log.password, $scope.log.server, groups);
+						authService.setCredentials($scope.log.username, $scope.log.password, groups);
 						setSingleNodeOrCluster();
 	                	redirectAfterLoggingIn();
                     });
@@ -60,7 +56,7 @@ define(['./_module'], function (app) {
 			}
 
 			function checkCookie () {
-				authService.existsAndValid($scope.log.server)
+				authService.existsAndValid()
 				.then(function () {
 					redirectAfterLoggingIn();
 				});

--- a/src/js/modules/security/controllers/SignOutCtrl.js
+++ b/src/js/modules/security/controllers/SignOutCtrl.js
@@ -3,10 +3,15 @@ define(['./_module'], function (app) {
     'use strict';
 
     return app.controller('SignOutCtrl', [
-		'$scope', '$state', 'AuthService',
-		function ($scope, $state, authService) {
+		'$scope', '$state', 'AuthService', '$rootScope',
+		function ($scope, $state, authService, $rootScope) {
 			authService.clearCredentials();
-			$state.go('signin');
+
+			if($rootScope.authentication.type === 'oauth'){
+				$rootScope.hideMenuOptions = true;
+			} else{
+				$state.go('signin');
+			}
 		}
 	]);
 

--- a/src/js/modules/security/module.js
+++ b/src/js/modules/security/module.js
@@ -11,7 +11,7 @@ define(['./_index'], function (app) {
         $stateProvider
             // ========================================SECURITY============
             .state('signin', {
-                url: '/',
+                url: 'signin',
                 templateUrl: 'signin.tpl.html',
                 controller: 'SignInCtrl',
                 data: {

--- a/src/js/modules/security/module.js
+++ b/src/js/modules/security/module.js
@@ -21,7 +21,7 @@ define(['./_index'], function (app) {
             .state('signout', {
                 url: 'signout',
                 parent: 'app',
-                template: '<div ui-view></div>',
+                template: '<div ui-view>{{logoutText}}</div>',
                 controller: 'SignOutCtrl',
                 data: {
                     title: 'Sign out'

--- a/src/js/modules/security/views/signin.tpl.html
+++ b/src/js/modules/security/views/signin.tpl.html
@@ -6,15 +6,6 @@
 			</a>
 		</h1>
 		<form novalidate name="login" ng-submit="signIn()" class="login-form">
-			<label for="server">Server</label>
-			<input type="text" 
-				   placeholder="127.0.0.1:2113"
-				   autofocus 
-				   required 
-				   name="server"
-				   ng-class="{ 'form-table--error' : login.server.$invalid && !login.server.$pristine }"
-				   ng-model="log.server" />
-
 			<label for="username">Username</label>
 			<input type="text" 
 				   placeholder="Username"

--- a/src/js/modules/users/controllers/UsersItemResetCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemResetCtrl.js
@@ -15,7 +15,7 @@ define(['./_module'], function (app) {
 				userService.resetPassword($scope.user.loginName, $scope.password)
 				.success(function () {
 					msg.success('Password has been reset');
-					authService.resetCredentials($scope.user.loginName, $scope.password, $rootScope.baseUrl)
+					authService.resetCredentials($scope.user.loginName, $scope.password)
 					.then(function(){
 						$state.go('^.details');
 					}, function(){

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -36,7 +36,19 @@ define(['es-ui'], function (app) {
                     setSingleNodeOrCluster();
                     redirectAfterLoggingIn();
                 }, function () {
-                    $state.go('signin');
+                    if($rootScope.authentication.type === 'oauth'){
+                        var authorizationEndpoint = $rootScope.authentication.properties.authorization_endpoint;
+                        var clientId = encodeURIComponent($rootScope.authentication.properties.client_id);
+                        var redirectUri = encodeURIComponent($rootScope.baseUrl + $rootScope.authentication.properties.redirect_uri);
+                        var responseType = encodeURIComponent($rootScope.authentication.properties.response_type);
+                        var scope = encodeURIComponent($rootScope.authentication.properties.scope);
+
+                        var authorizationUri = authorizationEndpoint + '?response_type=' + responseType + '&client_id=' + clientId + '&redirect_uri=' + redirectUri + '&scope=' + scope;
+                        window.location.href = authorizationUri;
+                    } else{
+                        //default behaviour is to sign-in with username/password
+                        $state.go('signin');
+                    }
                 });
             })
 			.error(function(){

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -11,19 +11,11 @@ define(['es-ui'], function (app) {
         '$rootScope', '$location', '$state', '$stateParams', 'AuthService', 'InfoService', 'ScavengeNotificationService', 'MessageService',
         function ($rootScope, $location, $state, $stateParams, authService, infoService, scavengeNotificationService, msg) {
             $rootScope.baseUrl = $location.protocol() + '://' + $location.host() + ':' + $location.port();
+            /*$rootScope.baseUrl = 'https://127.0.0.1:2113'; //uncomment during development*/
             $rootScope.projectionsEnabled = false;
             $rootScope.userManagementEnabled = false;
             $rootScope.streamsBrowserEnabled = false;
             $rootScope.singleNode = true;
-            var log = {
-                username: '',
-                password: '',
-                server: $location.protocol() + '://' + $location.host() + ':' + $location.port()
-            };
-
-            if(!$location.host()) {
-                log.server = 'https://127.0.0.1:2113';
-            }
 
             infoService.getInfo()
             .success(function(info){
@@ -36,7 +28,7 @@ define(['es-ui'], function (app) {
                 $rootScope.logoutEnabled = info.authentication.type !== 'insecure';
                 $rootScope.previousUrl = $location.$$path;
 
-                authService.existsAndValid(log.server)
+                authService.existsAndValid()
                 .then(function () {
                     setSingleNodeOrCluster();
                     redirectAfterLoggingIn();

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -16,6 +16,8 @@ define(['es-ui'], function (app) {
             $rootScope.userManagementEnabled = false;
             $rootScope.streamsBrowserEnabled = false;
             $rootScope.logoutEnabled = true;
+            $rootScope.logoutButtonText = 'Log Out';
+            $rootScope.logoutText = 'You have been logged out.';
             $rootScope.singleNode = true;
 
             authService.loadCredentials();
@@ -29,6 +31,8 @@ define(['es-ui'], function (app) {
                 $rootScope.streamsBrowserEnabled = info.features.atomPub === true;
                 $rootScope.authentication = info.authentication;
                 $rootScope.logoutEnabled = info.authentication.type !== 'insecure';
+                $rootScope.logoutButtonText = info.authentication.type === 'oauth' ? 'Disconnect' : $rootScope.logoutButtonText;
+                $rootScope.logoutText = info.authentication.type === 'oauth' ? 'You have been disconnected.' : $rootScope.logoutText;
                 $rootScope.previousUrl = $location.$$path;
 
                 authService.existsAndValid()

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -18,6 +18,8 @@ define(['es-ui'], function (app) {
             $rootScope.logoutEnabled = true;
             $rootScope.singleNode = true;
 
+            authService.loadCredentials();
+
             infoService.getInfo()
             .success(function(info){
                 $rootScope.esVersion = info.esVersion || '0.0.0.0';
@@ -38,7 +40,8 @@ define(['es-ui'], function (app) {
                 });
             })
 			.error(function(){
-				msg.failure('Could not load /info endpoint');
+                msg.failure('Could not load /info endpoint');
+                authService.clearCredentials();
             });
             
             function setSingleNodeOrCluster(){

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -15,6 +15,7 @@ define(['es-ui'], function (app) {
             $rootScope.projectionsEnabled = false;
             $rootScope.userManagementEnabled = false;
             $rootScope.streamsBrowserEnabled = false;
+            $rootScope.logoutEnabled = true;
             $rootScope.singleNode = true;
 
             infoService.getInfo()

--- a/src/js/services/AuthService.js
+++ b/src/js/services/AuthService.js
@@ -108,21 +108,27 @@ define(['./_module'], function (app) {
 		            clearCredentials($rootScope.baseUrl);
 		        },
 		        existsAndValid: function (server) {
-		        	var deferred = $q.defer();
-		        	var credentials = getCredentialsFromCookie(server);
-		        	if(!credentials) {
-		        		deferred.reject('Data does not exists');
-		        	} else {
-		        		this.validate(credentials, server)
-		        		.success(function() {
-		        			var groups = getGroupsFromCookie(server);
-							setUserRole(groups);
-		        			deferred.resolve();
-		        		})
-		        		.error(function (){
-		        			deferred.reject('Wrong credentials or server not exists');
-		        		});
-		        	}
+					var deferred = $q.defer();
+					
+					if($rootScope.authentication.type === 'insecure'){
+						setUserRole(['$admins']);
+						deferred.resolve();
+					} else {
+						var credentials = getCredentialsFromCookie();
+						if(!credentials) {
+							deferred.reject('Data does not exists');
+						} else {
+							this.validate(credentials, server)
+							.success(function() {
+								var groups = getGroupsFromCookie(server);
+								setUserRole(groups);
+								deferred.resolve();
+							})
+							.error(function (){
+								deferred.reject('Wrong credentials or server not exists');
+							});
+						}
+					}
 
 		        	return deferred.promise;
 		        },

--- a/src/js/services/AuthService.js
+++ b/src/js/services/AuthService.js
@@ -31,12 +31,8 @@ define(['./_module'], function (app) {
 
 			function clearCredentials(){
 	            document.execCommand('ClearAuthenticationCache');
-		        $http.defaults.headers.common.Authorization = 'Basic ';
-	            var escreds = $cookieStore.get('es-creds');
-	            if(escreds){
-	            	escreds = {};
-	            	$cookieStore.put('es-creds', escreds);
-	            }
+		        $http.defaults.headers.common.Authorization = undefined;
+	            $cookieStore.remove('es-creds');
 			}
 
 			function addCredentialsToCookie(username, password, groups){
@@ -75,7 +71,14 @@ define(['./_module'], function (app) {
 
 					setUserRole(groups);
 		            addCredentialsToCookie(username, password, groups);
-		        },
+				},
+				loadCredentials: function(){
+					var credentials = getCredentialsFromCookie();
+					if (!credentials){
+						return;
+					}
+					$http.defaults.headers.common.Authorization = 'Basic ' + credentials;
+				},
 		        clearCredentials: function () {
 		            clearCredentials();
 		        },

--- a/src/views/index.tpl.html
+++ b/src/views/index.tpl.html
@@ -5,7 +5,7 @@
 				<img src="images/logo.svg" height="29" width="119" alt="Event Store">
 			</a>
 		</h1>
-		<ul class="site-nav">
+		<ul class="site-nav" ng-hide="hideMenuOptions">
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('dashboard') }">
 				<a ui-sref="dashboard.list">Dashboard</a>
 			</li>
@@ -31,7 +31,7 @@
 				<a ng-class="{'disabled': !isAdmin || !userManagementEnabled}" ui-sref="users.list">Users</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('signout') }">
-				<a ng-class="{'disabled': !logoutEnabled}" ui-sref="signout">Log Out</a>
+				<a ng-class="{'disabled': !logoutEnabled}" ui-sref="signout">{{ logoutButtonText }}</a>
 			</li>
 		</ul>
 	</header>

--- a/src/views/index.tpl.html
+++ b/src/views/index.tpl.html
@@ -31,7 +31,7 @@
 				<a ng-class="{'disabled': !isAdmin || !userManagementEnabled}" ui-sref="users.list">Users</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('signout') }">
-				<a ui-sref="signout">Log Out</a>
+				<a ng-class="{'disabled': !logoutEnabled}" ui-sref="signout">Log Out</a>
 			</li>
 		</ul>
 	</header>


### PR DESCRIPTION
Related to: https://github.com/EventStore/EventStore.UI/issues/265

This PR adds support for the following authentication flows:
- Insecure (loads dashboard directly)
- Username/Password (internal, ldaps)
- OAuth 2.0 PKCE (redirects to authorization URL for approval, then back to the eventstore UI page)

It also removes the "server" box on the sign-in screen.

Note: The UI does not currently properly support Policy-Based Authorization (only Role-Based Authorization is supported). This will be dealt with in a separate PR.

The PR depends on the following PRs:
https://github.com/EventStore/EventStore/pull/2637
https://github.com/EventStore/EventStore.CommercialHA/pull/158