### PR TITLE
Remove the concept of role from the UI and handle authorization errors gracefully

### DIFF
--- a/src/js/config/http.js
+++ b/src/js/config/http.js
@@ -14,6 +14,45 @@ define(['es-ui'], function (app) {
             'ES-LongPoll': 5 // in sec
         };
 
+        $httpProvider.interceptors.push(['$q', function($q) {
+            return {
+                'responseError': function(rejection){
+                    var defer = $q.defer();
+
+                    //handle some common status codes
+                    var commonStatusCodes = {
+                        400 : 'Bad Request',
+                        401 : 'Unauthorized',
+                        403 : 'Forbidden',
+                        404 : 'Not Found',
+                        405 : 'Method Not Allowed',
+                        406 : 'Not Acceptable',
+                        409 : 'Conflict',
+                        500 : 'Internal Server Error',
+                        502 : 'Bad Gateway',
+                        503 : 'Service Unavailable'
+                    };
+
+                    var error = {
+                        message: 'Unknown error',
+                        statusCode : rejection.status,
+                        errorData: rejection.data
+                    };
+
+                    var contentTypeHeader = rejection.headers()['content-type'];
+                    if(contentTypeHeader && contentTypeHeader.indexOf('text/plain') !== -1 && rejection.data !== ''){
+                        error.message = rejection.data;
+                    } else if(rejection.statusText !== ''){
+                        error.message = rejection.statusText;
+                    } else if(rejection.status in commonStatusCodes){
+                        error.message = commonStatusCodes[rejection.status];
+                    }
+
+                    defer.reject(error);
+                    return defer.promise;
+                }
+            };
+        }]);
     }]);
 
 });

--- a/src/js/modules/admin/controllers/ScavengeCtrl.js
+++ b/src/js/modules/admin/controllers/ScavengeCtrl.js
@@ -47,12 +47,17 @@ define(['./_module'], function (app) {
     			        params: [$scope.scavengeId, $scope.pagination.fromEventNumber, $scope.pagination.pageSize]
     			    });
     			    scavengeInfoPoller.start();
-        			scavengeInfoPoller.promise.then(null, null, function(res) {
+                    scavengeInfoPoller.promise.then(null,
+                    function(error){
+                        msg.failure('Failed to retrieve scavenge info: ' + error.message);
+                    }, function(res) {
                         getScavengeInfo(res.entries);
                     });
                 } else {
                     adminService.scavengeInfo($scope.scavengeId, $scope.pagination.fromEventNumber, $scope.pagination.pageSize).then(function(res) {
                         getScavengeInfo(res.data.entries);
+                    }, function(error){
+                        msg.failure('Failed to retrieve scavenge info: ' + error.message);
                     });
                 }
             }

--- a/src/js/modules/admin/views/admin.tpl.html
+++ b/src/js/modules/admin/views/admin.tpl.html
@@ -25,7 +25,7 @@
                 </tr>
                 <tr ng-hide="subSystems">
                     <td>
-                        <em>No sub systems are running.</em>
+                        <em>{{noSubSystemsText}}</em>
                     </td>
                 </tr>
             </tbody>
@@ -42,9 +42,9 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-hide="scavengeHistory.length > 0">
+                <tr ng-hide="scavengeHistory">
                     <td colspan="4">
-                        <em>No scavenges have been run.</em>
+                        <em>{{noScavengeHistoryText}}</em>
                     </td>
                 </tr>
                 <tr ng-repeat="history in scavengeHistory track by history.scavengeId | orderBy : 'startTime'">
@@ -69,7 +69,7 @@
         </span>
         <ul class="page-nav">
             <li class="page-nav__item">
-                <a href="#/streams/$scavenges">Scavenge History</button>
+                <a ng-click="scavengeHistoryButton()">Scavenge History</button>
             </li>
         </ul>
     </div>

--- a/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
+++ b/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
@@ -2,8 +2,8 @@ define(['./_module'], function (app) {
 
     'use strict';
 
-    return app.controller('ClusterStatusListCtrl', ['$scope', 'poller', 'ClusterStatusService', 'InfoService', 'constants',
-		function ClusterStatusListCtrl($scope, poller, clusterStatusService, infoService, constants) {
+    return app.controller('ClusterStatusListCtrl', ['$scope', 'poller', 'ClusterStatusService', 'InfoService', 'constants', 'MessageService',
+		function ClusterStatusListCtrl($scope, poller, clusterStatusService, infoService, constants, msg) {
             $scope.replicas = [];
             var leaderNodeUrl = '';
 
@@ -27,7 +27,9 @@ define(['./_module'], function (app) {
 			        params: []
 			    });
 			    gossipQuery.start();
-			    gossipQuery.promise.then(null, null, function (response) {
+			    gossipQuery.promise.then(null, function(error){
+                    msg.failure('Failed to retrieve gossip info: ' + error.message);
+                }, function (response) {
 			        $scope.lastUpdatedTime = new Date();
 			        if (response.error) {
 			            $scope.errorMessage = 'couldn\'t connect to manager';
@@ -53,7 +55,9 @@ define(['./_module'], function (app) {
                     params: [leaderNodeUrl]
                 });
                 replicaStatsQuery.start();
-                replicaStatsQuery.promise.then(null, null, function(response) {
+                replicaStatsQuery.promise.then(null, function(error){
+                    msg.failure('Failed to retrieve replica stats: ' + error.message);
+                }, function(response) {
                     var leader = getLeaderNode();
                     for(var i = 0; i < response.length; i++)
                     {

--- a/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
+++ b/src/js/modules/clusterstatus/controllers/ClusterStatusListCtrl.js
@@ -16,9 +16,10 @@ define(['./_module'], function (app) {
 					}
 				}
 			},
-			function(){
-
+			function(error){
+                msg.failure('Failed to load options: ' + error.message);
             });
+
             var replicaStatsQuery;
 			function setupGossipPoller(){
 				var gossipQuery = poller.create({

--- a/src/js/modules/clusterstatus/controllers/ClusterStatusSnapshotCtrl.js
+++ b/src/js/modules/clusterstatus/controllers/ClusterStatusSnapshotCtrl.js
@@ -2,8 +2,8 @@ define(['./_module'], function (app) {
 
     'use strict';
 
-    return app.controller('ClusterStatusSnapshotCtrl', ['$scope', 'dateFilter', 'poller', 'SprintfService', 'ClusterStatusService',
-		function ClusterStatusSnapshotCtrl($scope, dateFilter, poller, sprintf, clusterStatusService) {
+    return app.controller('ClusterStatusSnapshotCtrl', ['$scope', 'dateFilter', 'poller', 'SprintfService', 'ClusterStatusService', 'MessageService',
+		function ClusterStatusSnapshotCtrl($scope, dateFilter, poller, sprintf, clusterStatusService, msg) {
 		    function format(data) {
 		    	var nodes = data.members;
 		        var snapshotLines = sprintf.format('%s\n', 'Snapshot taken at ' + dateFilter(new Date(), 'yyyy-MM-d HH:mm:ss'));
@@ -26,6 +26,10 @@ define(['./_module'], function (app) {
 		    $scope.$on('$destroy', function () {
 				poller.clear();
 			});
-			clusterStatusService.gossip().success(format);
+			clusterStatusService.gossip().then(function(res){
+				format(res.data);
+			}, function(error){
+				msg.failure('Failed to retrieve gossip info: ' + error.message);
+			});
 		}]);
 });

--- a/src/js/modules/competing/controllers/SubscriptionsDeleteCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsDeleteCtrl.js
@@ -15,9 +15,11 @@ define(['./_module'], function (app) {
 					return;
 				}
 				competingService.delete($scope.stream, $scope.subscription)
-					.success(function(data){
+				.then(function(){
 						msg.success('Subscription has been deleted');
 						$state.go('subscriptions.list');
+				},function(error){
+						msg.failure('Failed to delete subscription: ' + error.message);
 				});
 			};
 		}

--- a/src/js/modules/competing/controllers/SubscriptionsDetailCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsDetailCtrl.js
@@ -8,8 +8,10 @@ define(['./_module'], function (app) {
 			$scope.streamId = $stateParams.streamId;
 			$scope.groupName = $stateParams.groupName;
 			competingService.subscriptionDetail($scope.streamId, $scope.groupName)
-				.success(function(data){
-					$scope.detail = data;
+				.then(function(res){
+					$scope.detail = res.data;
+				}, function(error){
+					msg.failure('Failed to retrieve subscription details: ' + error.message);
 				});
 		}
 	]);

--- a/src/js/modules/competing/controllers/SubscriptionsEditCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsEditCtrl.js
@@ -23,8 +23,10 @@ define(['./_module'], function (app) {
 			}];
 
 			competingService.subscriptionDetail($scope.stream, $scope.subscription)
-				.success(function(data){
-					$scope.config = data.config;
+			.then(function(res){
+					$scope.config = res.data.config;
+			}, function(error){
+					msg.failure('Failed to retrieve subscription details: ' + error.message);
 			});
 
 			$scope.namedConsumerStrategy = 'RoundRobin';
@@ -54,15 +56,19 @@ define(['./_module'], function (app) {
 				};
 
 				competingService.update($scope.stream, $scope.subscription, param)
-					.success(function (data, status, headers) {
+					.then(function (res) {
+						var headers = res.headers;
 						var location = headers()['location'];
 						msg.success('Subscription has been updated');
 						$state.go('subscriptions.list', {
 							location: encodeURIComponent(location)
 						});
-					})
-					.error(function (response) {
-						msg.failure('Coudn\'t update subscription because ' + response.reason);
+					}, function (error) {
+						var errorMsg = error.message;
+						if(error.errorData && error.errorData.reason){
+							errorMsg = error.errorData.reason;
+						}
+						msg.failure('Failed to update subscription: ' + errorMsg);
 					});
 			};
 		}

--- a/src/js/modules/competing/controllers/SubscriptionsListCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsListCtrl.js
@@ -15,8 +15,8 @@ define(['./_module'], function (app) {
 			$scope.replayParkedMessages = function(streamId, groupName){
 				competingService.replayParked(streamId, groupName).then(function () {
 					msg.success('Replaying Parked Messages');
-				}, function (err) {
-					msg.failure('Failed to initiate replaying of parked messages because ' + err);
+				}, function (error) {
+					msg.failure('Failed to initiate replaying of parked messages: ' + error.message);
 				});
 			};
 
@@ -26,8 +26,8 @@ define(['./_module'], function (app) {
 			subscriptionsPoll.promise.then(null, null, function (data) { 
 				$scope.subscriptions = subscriptionsMapper.map(data, $scope.subscriptions);
 			});
-			subscriptionsPoll.promise.catch(function () {
-				msg.failure('An error occured.');
+			subscriptionsPoll.promise.catch(function (error) {
+				msg.failure('Failed to retrieve list of subscriptions: ' + error.message);
 				$scope.subscriptions = null;
 				subscriptionsPoll.stop(); 
 			});

--- a/src/js/modules/competing/controllers/SubscriptionsNewCtrl.js
+++ b/src/js/modules/competing/controllers/SubscriptionsNewCtrl.js
@@ -46,15 +46,15 @@ define(['./_module'], function (app) {
 				};
 
 				competingService.create($scope.stream, $scope.subscription, param)
-					.then(function (data, status) {
+					.then(function () {
 						msg.success('Subscription has been created');
 						$state.go('^.list');
-					}, function(response){
-						var error = response.statusText;
-						if(response.data && response.data.reason) {
-							error = response.data.reason;
+					}, function(error){
+						var errorMsg = error.message;
+						if(error.errorData && error.errorData.reason){
+							errorMsg = error.errorData.reason;
 						}
-						msg.failure('Coudn\'t create new subscription because ' + error);
+						msg.failure('Failed to create new subscription: ' + errorMsg);
 					});
 			};
 

--- a/src/js/modules/competing/views/subscription.row.tpl.html
+++ b/src/js/modules/competing/views/subscription.row.tpl.html
@@ -10,19 +10,19 @@
 </td>
 <td>
     <ul class="page-nav">
-        <li ng-show="$root.isAdminOrOps" class="page-nav__item">
+        <li class="page-nav__item">
             <a ui-sref="^.item.edit({streamId: esSubscription.eventStreamId, groupName: esSubscription.groupName})">Edit</a>
         </li>
-        <li ng-show="$root.isAdminOrOps" class="page-nav__item">
+        <li class="page-nav__item">
             <a ui-sref="^.item.delete({streamId: esSubscription.eventStreamId, groupName: esSubscription.groupName})">Delete</a>
         </li>
         <li class="page-nav__item">
             <a ui-sref="^.item.detail({streamId: esSubscription.eventStreamId, groupName: esSubscription.groupName})">Detail</a>
         </li>
-        <li ng-show="$root.isAdminOrOps" class="page-nav__item">
+        <li class="page-nav__item">
             <a ng-click="$parent.replayParkedMessages(esSubscription.eventStreamId, esSubscription.groupName)">Replay Parked Messages</a>
         </li>
-        <li ng-show="$root.isAdminOrOps" class="page-nav__item">
+        <li class="page-nav__item">
             <a ui-sref="^.item.viewparkedmessages({streamId: esSubscription.eventStreamId, groupName: esSubscription.groupName})">View Parked Messages</a>
         </li>
     </ul>

--- a/src/js/modules/competing/views/subscriptions.list.tpl.html
+++ b/src/js/modules/competing/views/subscriptions.list.tpl.html
@@ -1,10 +1,7 @@
 <header class="page-header">
     <h2 class="page-title">Dashboard</h2>
     <ul class="page-nav">
-        <li ng-show="!isAdminOrOps" class="page-nav__item">
-            <em>You must be in the $admins or $ops group to manage persistent subscriptions and replay parked messages.</em>
-        </li>
-        <li ng-show="isAdminOrOps" class="page-nav__item">
+        <li class="page-nav__item">
             <a ui-sref="^.new">New Subscription</a>
         </li>
     </ul>

--- a/src/js/modules/dashboard/controllers/DashboardListCtrl.js
+++ b/src/js/modules/dashboard/controllers/DashboardListCtrl.js
@@ -19,10 +19,10 @@ define(['./_module'], function (app) {
 			statsPoll.promise.then(null, null, function (data) { 
 				$scope.queues = dashboardMapper.map(data, $scope.queues);
 			});
-			statsPoll.promise.catch(function () {
-				msg.failure('An error occured.');
+			statsPoll.promise.catch(function (error) {
+				msg.failure('Failed to fetch dashboard stats: ' + error.message);
 				$scope.queues = null;
-				statsPoll.stop(); // if error we do not want to continue...
+				statsPoll.stop();
 			});
 
             // TCP Stats
@@ -42,6 +42,12 @@ define(['./_module'], function (app) {
                     stat.averageBytesReceivedPerSecond = previous ? stat.totalBytesReceived - previous.totalBytesReceived : 0;
                 }
                 $scope.tcpStats = data;
+            });
+
+            tcpStatsPoll.promise.catch(function (error) {
+                msg.failure('Failed to fetch TCP connection stats: ' + error.message);
+                $scope.tcpStats = null;
+                tcpStatsPoll.stop();
             });
 
             function getPreviousTcpStat(connectionId, previousTcpStats) {

--- a/src/js/modules/dashboard/controllers/DashboardSnapshotCtrl.js
+++ b/src/js/modules/dashboard/controllers/DashboardSnapshotCtrl.js
@@ -3,8 +3,8 @@ define(['./_module'], function (app) {
     'use strict';
 
     return app.controller('DashboardSnaphostCtrl', [
-		'$scope', 'DashboardService', 'SprintfService',
-		function ($scope, dashboardService, print) {
+		'$scope', 'DashboardService', 'SprintfService', 'MessageService',
+		function ($scope, dashboardService, print, msg) {
 
 			function format (data) {
 				var snapshot = 'Snapshot taken at: ' + (new Date()).toString();
@@ -31,7 +31,11 @@ define(['./_module'], function (app) {
 
 				$scope.snapshot = snapshot;
 			}
-			dashboardService.stats().success(format);
+			dashboardService.stats().then(function(res){
+				 format(res.data);
+			}, function(error){
+				msg.failure('Failed to retrieve dashboard stats: ' + error.message);
+			});
 		}
 	]);
 });

--- a/src/js/modules/dashboard/views/dashboard.list.tpl.html
+++ b/src/js/modules/dashboard/views/dashboard.list.tpl.html
@@ -106,7 +106,7 @@
 	</tbody>
     <tbody ng-hide="tcpStats.length">
         <tr>
-            <td colspan="9">
+            <td colspan="10">
                 <em>No Connections</em>
             </td>
         </tr>

--- a/src/js/modules/projections/controllers/ProjectionsItemConfigCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemConfigCtrl.js
@@ -9,11 +9,11 @@ define(['./_module'], function (app) {
 
 			$scope.location = $stateParams.location;
 			projectionsService.configuration($scope.location)
-			.success(function (data) {
-				$scope.config = data;
-			})
-			.error(function () {
-				msg.failure('Projection does not exist or is inaccessible');
+			.then(function (res) {
+				$scope.config = res.data;
+			}, function (error) {
+				$scope.config = {};
+				msg.failure('Failed to load projection configuration: ' + error.message);
 			});
 
 			monitor.start($scope.location, {
@@ -30,7 +30,7 @@ define(['./_module'], function (app) {
 				}
 
 				if(data.state) {
-					$scope.sate = data.state;
+					$scope.state = data.state;
 				}
 			});
 
@@ -46,11 +46,10 @@ define(['./_module'], function (app) {
 					maxAllowedWritesInFlight: $scope.config.maxAllowedWritesInFlight,
 				};
 				projectionsService.updateConfiguration($scope.location, param)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection configuration saved');
-				})
-				.error(function (failureMessage) {
-					msg.failure(failureMessage, 'Projection configuration not saved');
+				}, function (error) {
+					msg.failure('Failed to save projection configuration: ' + error.message);
 				});
 
 			};

--- a/src/js/modules/projections/controllers/ProjectionsItemDeleteCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemDeleteCtrl.js
@@ -14,14 +14,18 @@ define(['./_module'], function (app) {
 			};
 
 			projectionsService.state($scope.location)
-			.success(function (data) {
-				$scope.projection.state = data;
+			.then(function (res) {
+				$scope.projection.state = res.data;
+			}, function (error) {
+				msg.failure('Failed to load the projection state: ' + error.message);
 			});
 
 			projectionsService.query($scope.location)
-			.success(function (data) {
-				$scope.projection.source = data.query;
-				$scope.projection.name = data.name;
+			.then(function (res) {
+				$scope.projection.source = res.data.query;
+				$scope.projection.name = res.data.name;
+			}, function (error) {
+				msg.failure('Failed to load projection source: ' + error.message);
 			});
 
 			function removeProjection(location){
@@ -30,12 +34,11 @@ define(['./_module'], function (app) {
 					deleteStateStream: $scope.deleteState ? 'yes' : 'no',
 					deleteEmittedStreams: $scope.deleteEmittedStreams ? 'yes' : 'no'
 				})
-				.success(function () {
+				.then(function () {
 					msg.success('Projection has been removed');
 					$state.go('projections.list');
-				})
-				.error(function () {
-					msg.failure('Projection not removed');
+				}, function (error) {
+					msg.failure('Failed to remove projection: ' + error.message);
 				});
 			}
 
@@ -44,14 +47,13 @@ define(['./_module'], function (app) {
 				$event.stopPropagation();
 
 				projectionsService.disable($scope.location)
-				.success(function () {
+				.then(function () {
 					removeProjection($scope.location);
-				})
-				.error(function (message) {
-					if(message.indexOf('Not enabled') !== -1){
+				}, function (error) {
+					if(error.message.indexOf('Not enabled') !== -1) {
 						removeProjection($scope.location);
-					}else{
-						msg.failure('Projection could not be stopped');
+					} else{
+						msg.failure('Failed to stop projection: ' + error.message);
 					}
 				});
 			};

--- a/src/js/modules/projections/controllers/ProjectionsItemDetailsCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemDetailsCtrl.js
@@ -82,31 +82,28 @@ define(['./_module'], function (app) {
 				}
 
 				projectionsService.reset($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection has been reset');
-				})
-				.error(function () {
-					msg.failure('Reset failed');
+				}, function (error) {
+					msg.failure('Failed to reset projection: ' + error.message);
 				});
 			};
 
 			$scope.start = function () {
 				projectionsService.enable($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection started');
-				})
-				.error(function () {
-					msg.failure('projection could not be started');
+				}, function (error) {
+					msg.failure('Failed to start projection: ' + error.message);
 				});
 			};
 
 			$scope.stop = function () {
 				projectionsService.disable($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection has been stopped');
-				})
-				.error(function () {
-					msg.failure('Projection could not be stopped');
+				}, function (error) {
+					msg.failure('Failed to stop projection: ' + error.message);
 				});
 			};
 

--- a/src/js/modules/projections/controllers/ProjectionsItemEditCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsItemEditCtrl.js
@@ -29,7 +29,8 @@ define(['./_module'], function (app) {
 
 			// load query info
 			projectionsService.query($scope.location)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.query = data.query;
 				if(data.definition) {
 					$scope.stream = data.definition.resultStreamName;
@@ -37,9 +38,8 @@ define(['./_module'], function (app) {
 					$scope.stream = undefined;
 				}
 				$scope.emit = data.emitEnabled;
-			})
-			.error(function () {
-				msg.failure('Projection does not exist or is inaccessible');
+			}, function (error) {
+				msg.failure('Failed to load projection source: ' + error.message);
 			});
 
 			monitor.start($scope.location, {
@@ -72,11 +72,10 @@ define(['./_module'], function (app) {
 				projectionsService.updateQuery($scope.location,
 					$scope.emit ? 'yes' : 'no',
 					$scope.query)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection saved');
-				})
-				.error(function () {
-					msg.failure('Projection not saved');
+				}, function (error) {
+					msg.failure('Failed to save projection: ' + error.message);
 				});
 
 			};
@@ -90,31 +89,28 @@ define(['./_module'], function (app) {
 				}
 
 				projectionsService.reset($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection has been reset');
-				})
-				.error(function () {
-					msg.failure('Reset failed');
+				}, function (error) {
+					msg.failure('Failed to reset projection: ' + error.message);
 				});
 			};
 
 			$scope.start = function () {
 				projectionsService.enable($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection started');
-				})
-				.error(function () {
-					msg.failure('projection could not be started');
+				}, function (error) {
+					msg.failure('Failed to start projection: ' + error.message);
 				});
 			};
 
 			$scope.stop = function () {
 				projectionsService.disable($scope.location)
-				.success(function () {
+				.then(function () {
 					msg.success('Projection stopped');
-				})
-				.error(function () {
-					msg.failure('Projection could not be stopped');
+				}, function (error) {
+					msg.failure('Failed to stop projection: ' + error.message);
 				});
 			};
 

--- a/src/js/modules/projections/controllers/ProjectionsListCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsListCtrl.js
@@ -23,8 +23,8 @@ define(['./_module'], function (app) {
 				$scope.projections = projectionsMapper.map(data);
 			});
 
-			all.promise.catch(function () {
-				msg.failure('An error occurred');
+			all.promise.catch(function (error) {
+				msg.failure('Failed to retrieve list of projections: ' + error.message);
 				all.stop();
 			});
 
@@ -40,8 +40,8 @@ define(['./_module'], function (app) {
 
 				projectionsService.disableAll().then(function () {
 					msg.success('All projections have been disabled');
-				}, function (err) {
-					msg.failure('Disabling all the projections have failed, reason :' + '\n\r' + err);
+				}, function (errorMessage) {
+					msg.failure('Failed to disable all the projections: ' + errorMessage);
 				});
 			};
 
@@ -57,8 +57,8 @@ define(['./_module'], function (app) {
 
 				projectionsService.enableAll().then(function () {
 					msg.success('All projections have been enabled');
-				}, function (err) {
-					msg.failure('Enabling all projections have failed, reason : ' + '\n\r' + err);
+				}, function (errorMessage) {
+					msg.failure('Failed to enable all projections: ' + errorMessage);
 				});
 			};
 

--- a/src/js/modules/projections/controllers/ProjectionsNewCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsNewCtrl.js
@@ -47,14 +47,14 @@ define(['./_module'], function (app) {
 				};
 
 				projectionsService.create($scope.mode, $scope.source, param)
-					.success(function (data, status, headers) {
+					.then(function (res) {
+						var headers = res.headers;
 						var location = headers()['location'];
 						$state.go('^.item.details', {
 							location: encodeURIComponent(location)
 						});
-					})
-					.error(function () {
-						msg.failure('Coudn\'t create new projection');
+					}, function (error) {
+						msg.failure('Failed to create new projection: ' + error.message);
 					});
 			};
 

--- a/src/js/modules/projections/controllers/ProjectionsStandardCtrl.js
+++ b/src/js/modules/projections/controllers/ProjectionsStandardCtrl.js
@@ -40,14 +40,14 @@ define(['./_module'], function (app) {
 				}
 
 				projectionsService.createStandard($scope.name, $scope.type, $scope.source)
-					.success(function (data, status, headers) {
+					.then(function (res) {
+						var headers = res.headers;
 						var location = headers()['location'];
 						$state.go('^.item.details', {
 							location: encodeURIComponent(location)
 						});
-					})
-					.error(function () {
-						msg.failure('Coudn\'t create new standard projection');
+					}, function (error) {
+						msg.failure('Failed to create new standard projection: ' + error.message);
 					});
 			};
 		}

--- a/src/js/modules/projections/controllers/QueryCtrl.js
+++ b/src/js/modules/projections/controllers/QueryCtrl.js
@@ -14,7 +14,9 @@ define(['./_module'], function (app) {
 				location = $stateParams.location;
                 projectionsService.query(location).then(function (result) {
 	                $scope.query = result.data.query;
-                });
+                }, function(error){
+									msg.failure('Failed to load query source: ' + error.message);
+								});
 			} else if ($stateParams.initStreamId) {
                           $scope.query = 'fromStream(\'' + $stateParams.initStreamId + '\')\n  .when({\n  })';
                         } else {

--- a/src/js/modules/projections/services/AtomEventsReader.js
+++ b/src/js/modules/projections/services/AtomEventsReader.js
@@ -50,8 +50,10 @@ define(['./_module'], function (app) {
 					onContinuePollCallback();
 				}
 				streams.validateFullUrl(previous.uri)
-				.success(function (data) {
+				.then(function () {
 					onContinuePollCallback();
+				}, function (error) {
+					console.error('Failed to validate URL: ' + previous.uri + '. Error: ' + error.message);
 				});
 			}
 
@@ -89,9 +91,9 @@ define(['./_module'], function (app) {
 						});
 					});
 
-					polling.promise.catch(function () {
+					polling.promise.catch(function (error) {
 						poller.clear();
-						deferredGlobal.reject();
+						deferredGlobal.reject(error);
 					});
 					
 					return deferredGlobal.promise;

--- a/src/js/modules/projections/views/projections.item.details.tpl.html
+++ b/src/js/modules/projections/views/projections.item.details.tpl.html
@@ -3,33 +3,30 @@
 <header class="page-header">
 		<h2 class="page-title">Projection Details</h2>
 		<ul class="page-nav">
-			<li ng-show="!isAdminOrOps && !isTransientProjection" class="page-nav__item">
-				<em>You must be in the $admins or $ops group to manage non-transient projections</em>
-			</li>
-			<li ng-show="isAdminOrOps" class="page-nav__item">
+			<li class="page-nav__item">
 				<button ng-click="start()" 
 					ng-disabled="isRunning"
 					href="#">Start</button>
 				
 			</li>
-			<li ng-show="isAdminOrOps || isTransientProjection" class="page-nav__item">
+			<li class="page-nav__item">
 				<button ng-click="stop()" 
 				   ng-disabled="isStopped"
 				   >Stop</button>
 				
 			</li>
-			<li ng-show="isAdminOrOps" class="page-nav__item">
+			<li class="page-nav__item">
 				<a ui-sref="^.edit">Edit</a>
-			<li ng-show="isAdminOrOps" class="page-nav__item">
+			<li class="page-nav__item">
 				<a ui-sref="^.config">Config</a>
-			<li ng-show="isAdminOrOps && !isTransientProjection" class="page-nav__item">
+			<li ng-show="!isTransientProjection" class="page-nav__item">
 				<a ui-sref="^.debug">Debug</a>
 			</li>
-			<li ng-show="isAdminOrOps" class="page-nav__item">
+			<li class="page-nav__item">
 				<a ui-sref="^.delete" ng-if="!isRunning">Delete</a>
 				<a title="a Projection must be stopped before it may be deleted." ng-if="isRunning" ng-disabled="isRunning">Delete</a>
 			</li>
-			<li ng-show="isAdminOrOps && !isTransientProjection" class="page-nav__item">
+			<li ng-show="!isTransientProjection" class="page-nav__item">
 				<button ng-click="reset($event)">Reset</button>
 			</li>
 			<li class="page-nav__item">

--- a/src/js/modules/projections/views/projections.list.tpl.html
+++ b/src/js/modules/projections/views/projections.list.tpl.html
@@ -2,20 +2,17 @@
 		<header class="page-header">
 			<h2 class="page-title">Projections</h2>
 			<ul class="page-nav">
-				<li ng-show="!isAdminOrOps" class="page-nav__item">
-					<em>You must be in the $admins or $ops group to manage non-transient projections</em>
-				</li>
-				<li ng-show="isAdminOrOps" class="page-nav__item">
+				<li class="page-nav__item">
 					<a ng-click="disableAll($event)">Disable All</a>
 				</li>
-				<li ng-show="isAdminOrOps" class="page-nav__item">
+				<li class="page-nav__item">
 					<a ng-click="enableAll($event)">Enable All</a>
 				</li>
 				<li class="page-nav__item">
 					<a ng-if="includeQueries" class="highlight" ng-click="toggleIncludeQueries()">Don't Include Queries</a>
 					<a ng-if="!includeQueries" ng-click="toggleIncludeQueries()">Include Queries</a>
 				</li>
-				<li ng-show="isAdminOrOps" class="page-nav__item">
+				<li class="page-nav__item">
 					<a ui-sref="^.new">New Projection</a>
 				</li>
 			</ul>

--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -20,11 +20,9 @@ define(['./_module'], function (app) {
 
 				authService.validate($scope.log.username, $scope.log.password)
 				.success(function () {
-                    authService.getUserGroups($scope.log.username).then(function(groups) {
-						authService.setCredentials($scope.log.username, $scope.log.password, groups);
-						setSingleNodeOrCluster();
-	                	redirectAfterLoggingIn();
-                    });
+					authService.setCredentials($scope.log.username, $scope.log.password);
+					setSingleNodeOrCluster();
+					redirectAfterLoggingIn();
 				})
 				.error(function () {
 					msg.warn('Incorrect user credentials supplied.');

--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -34,15 +34,20 @@ define(['./_module'], function (app) {
 
 			function setSingleNodeOrCluster(){
 				scavengeNotificationService.start();
-				infoService.getOptions().then(function onGetOptions(response){
-					var options = response.data;
+				infoService.getOptions().then(function(res){
+					var options = res.data;
 					for (var index in options) {
 						if(options[index].name === 'ClusterSize' && options[index].value > 1){
 							$rootScope.singleNode = false;
 						}
 					}
+				},function(error){
+					if(error.statusCode === 401){
+						return;
+					}
+					msg.failure('Failed to load options: ' + error.message);
 				});
-            }
+      }
 
 			function redirectAfterLoggingIn() {
 				if($rootScope.previousUrl && $rootScope.previousUrl !== '/'){

--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -19,13 +19,16 @@ define(['./_module'], function (app) {
 				}
 
 				authService.validate($scope.log.username, $scope.log.password)
-				.success(function () {
+				.then(function () {
 					authService.setCredentials($scope.log.username, $scope.log.password);
 					setSingleNodeOrCluster();
 					redirectAfterLoggingIn();
-				})
-				.error(function () {
-					msg.warn('Incorrect user credentials supplied.');
+				}, function (error) {
+					if(error.statusCode === 401){
+						msg.warn('Incorrect user credentials supplied.');
+					} else{
+						msg.failure('Failed to validate user: ' + error.message);
+					}
 				});
 			};
 

--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -32,17 +32,15 @@ define(['./_module'], function (app) {
 			};
 
 			function setSingleNodeOrCluster(){
-                if($rootScope.isAdminOrOps) {
-                    scavengeNotificationService.start();
-                    infoService.getOptions().then(function onGetOptions(response){
-                        var options = response.data;
-                        for (var index in options) {
-                            if(options[index].name === 'ClusterSize' && options[index].value > 1){
-                                $rootScope.singleNode = false;
-                            }
-                        }
-                    });
-                }
+				scavengeNotificationService.start();
+				infoService.getOptions().then(function onGetOptions(response){
+					var options = response.data;
+					for (var index in options) {
+						if(options[index].name === 'ClusterSize' && options[index].value > 1){
+							$rootScope.singleNode = false;
+						}
+					}
+				});
             }
 
 			function redirectAfterLoggingIn() {

--- a/src/js/modules/streams/controllers/StreamsAddEventCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsAddEventCtrl.js
@@ -50,8 +50,8 @@ define(['./_module'], function (app) {
                                   msg.success('Event ' + $scope.eventId + '(' + $scope.eventType + ') created');
                                   $scope.eventId = generateArbitraryEventId();
                                 },
-                                function (response) {
-                                  msg.failure('Could not create event. ' + response.statusText);
+                                function (error) {
+                                  msg.failure('Failed to create event: ' + error.message);
                                 }
                             );
                         };

--- a/src/js/modules/streams/controllers/StreamsItemAclCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsItemAclCtrl.js
@@ -13,7 +13,8 @@ define(['./_module'], function (app) {
 			$scope.streamId = $stateParams.streamId;
 			
 			streamsService.getAcl($scope.streamId)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				if(!data) {
 					return;
 				}
@@ -26,9 +27,8 @@ define(['./_module'], function (app) {
 					$scope.metareader = data.$acl.$mr;
 					$scope.metawriter = data.$acl.$mw;
 				}
-			})
-			.error(function () {
-				msg.failure('could not load metadata for stream: ' + $scope.streamId);
+			}, function (error) {
+				msg.failure('Failed to load metadata for stream \'' + $scope.streamId + '\': ' + error.message);
 
 				$state.go('^.events');
 			});
@@ -47,7 +47,9 @@ define(['./_module'], function (app) {
 					.then(function () {
 						msg.info('acl updated');
 						$state.go('^.events');
-					}, err);
+					}, function(error){
+						msg.failure('Failed to update metadata for stream \'' + $scope.streamId + '\': ' + error.message);
+					});
 			};
 		}
 	]);

--- a/src/js/modules/streams/controllers/StreamsItemEventsCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsItemEventsCtrl.js
@@ -16,8 +16,8 @@ define(['./_module'], function (app) {
 			$scope.source = $stateParams.source;
 
 			atom.start($stateParams)
-			.then(null, function () {
-				msg.failure('stream does not exist');
+			.then(null, function (error) {
+				msg.failure('Failed to read events for stream \''+$scope.streamId+'\': ' + error.message);
 			}, function (data) {
 				$scope.$parent.headOfStream = data.headOfStream;	
 				$scope.$broadcast('add-link-header', findSelf(data.links));
@@ -62,20 +62,18 @@ define(['./_module'], function (app) {
 
 			function deleteStream(streamId){
 				if (streamId === undefined) {
-					msg.info('You cannot delete this stream as the stream id is empty of undefined');
+					msg.info('You cannot delete this stream as the stream ID is empty or undefined');
 					return;
 				}
 				var confirmation = msg.confirm('Are you sure you want to delete the stream: ' + streamId + '?');
 				if(!confirmation) {
 					return;
 				}
-				streamsService.deleteStream(streamId).then(function(success){
-					if(success)
-					{
-						msg.info('Stream ' + streamId + ' deleted');
-					}else{
-						msg.warn('Could not delete stream ' + streamId);
-					}
+				streamsService.deleteStream(streamId).then(function(){
+					msg.info('Stream \'' + streamId + '\' deleted');
+				},
+				function(error){
+					msg.failure('Failed to delete stream \''+streamId+'\': ' + error.message)
 				});
 			}
 

--- a/src/js/modules/streams/controllers/StreamsListCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsListCtrl.js
@@ -26,25 +26,47 @@ define(['./_module'], function (app) {
 				$event.preventDefault();
 				$event.stopPropagation();
 
-				streamsService.checkStreamExists($scope.search).then(function(exists) {
-					if(exists) {
+				streamsService.checkStreamExists($scope.search).then(function() {
 						$state.go('^.item.events', { streamId: $scope.search });
+				}, function(error){
+					if(error.statusCode === 404){
+						msg.warn('The stream \'' + $scope.search +'\' does not exist.');
 					} else {
-						msg.warn('Could not open stream ' + $scope.search +'. This usually means the stream does not exist or you do not have permission to view it');
+						msg.failure('Failed to read stream \''+$scope.search+'\': ' + error.message);
 					}
 				});
 			};
 
 			$scope.search = '$all';
+			$scope.noChangedStreamsText = 'No recently changed streams';
+			$scope.noCreatedStreamsText = 'No recently created streams';
 		
-			streamsService.recentlyChangedStreams()
-			.success(function (data) {
-				$scope.changedStreams = filter(data.entries);
+			streamsService.recentlyChangedStreams().then(
+			function (res) {
+				$scope.changedStreams = filter(res.data.entries);
+			},
+			function(error){
+				if(error.statusCode === 401){
+					$scope.noChangedStreamsText = 'You are not authorized to view recently changed streams';
+				} else if(error.statusCode === 404){
+					$scope.noChangedStreamsText = 'No recently changed streams';
+				} else{
+					msg.failure('Failed to load recently changed streams: ' + error.message);
+				}
 			});
 
-			streamsService.recentlyCreatedStreams()
-			.success(function (data) {
-				$scope.createdStreams = filter(data.entries);
+			streamsService.recentlyCreatedStreams().then(
+			function (res) {
+				$scope.createdStreams = filter(res.data.entries);
+			},
+			function(error){
+				if(error.statusCode === 401){
+					$scope.noCreatedStreamsText = 'You are not authorized to view recently created streams';
+				} else if(error.statusCode === 404){
+					$scope.noCreatedStreamsText = 'No recently created streams';
+				} else{
+					msg.failure('Failed to load recently created streams: ' + error.message);
+				}
 			});
 		}
 	]);

--- a/src/js/modules/streams/controllers/StreamsListCtrl.js
+++ b/src/js/modules/streams/controllers/StreamsListCtrl.js
@@ -35,19 +35,17 @@ define(['./_module'], function (app) {
 				});
 			};
 
-			if($rootScope.isAdmin !== false) {
-				$scope.search = '$all';
-			
-				streamsService.recentlyChangedStreams()
-				.success(function (data) {
-					$scope.changedStreams = filter(data.entries);
-				});
+			$scope.search = '$all';
+		
+			streamsService.recentlyChangedStreams()
+			.success(function (data) {
+				$scope.changedStreams = filter(data.entries);
+			});
 
-				streamsService.recentlyCreatedStreams()
-				.success(function (data) {
-					$scope.createdStreams = filter(data.entries);
-				});
-			}
+			streamsService.recentlyCreatedStreams()
+			.success(function (data) {
+				$scope.createdStreams = filter(data.entries);
+			});
 		}
 	]);
 });

--- a/src/js/modules/streams/services/StreamsService.js
+++ b/src/js/modules/streams/services/StreamsService.js
@@ -14,24 +14,14 @@ define(['./_module'], function(app) {
                         return $http.get(url);
                     },
                     updateAcl: function(streamId, post) {
-                        var deferred = $q.defer();
-
                         var url = urlBuilder.build(urls.streams.updateAcl, streamId);
                         
-                        $http.post(url, JSON.stringify(post), {
+                        return $http.post(url, JSON.stringify(post), {
                             headers: {
                                 'ES-EventType':'$metadata',
                                 'Content-Type':'application/json'
                             }
-                        })
-                        .success(function() {
-                            deferred.resolve();
-                        })
-                        .error(function() {
-                            deferred.reject();
                         });
-
-                        return deferred.promise;
                     },
                     addEvent: function (streamId, eventData) {
                         var url = urlBuilder.build(urls.streams.events, streamId);
@@ -88,24 +78,12 @@ define(['./_module'], function(app) {
                         return $http.get(url, header);
                     },
                     checkStreamExists: function(streamId) {
-                        var deferred = $q.defer();
                         var url = urlBuilder.build(urls.streams.events, streamId);
-                        $http.get(url).success(function() {
-                            deferred.resolve(true);
-                        }).error(function() {
-                            deferred.resolve(false);
-                        });
-                        return deferred.promise;
+                        return $http.get(url);
                     },
                     deleteStream: function(streamId) {
-                        var deferred = $q.defer();
                         var url = urlBuilder.build(urls.streams.events, streamId);
-                        $http.delete(url).success(function() {
-                            deferred.resolve(true);
-                        }).error(function() {
-                            deferred.resolve(false);
-                        });
-                        return deferred.promise;
+                        return $http.delete(url);
                     }
                 };
             }

--- a/src/js/modules/streams/views/streams.item.tpl.html
+++ b/src/js/modules/streams/views/streams.item.tpl.html
@@ -5,7 +5,7 @@
             <a ng-class="{highlight: isPolling == false}" ng-click="togglePause()" ng-show="headOfStream">{{ isPolling == true ? 'Pause' : 'Resume' }}</a>
         </li>
         <li class="page-nav__item">
-            <a ui-sref=".acl" ng-show="streamId !== '$all' && isAdmin">Edit ACL</a>
+            <a ui-sref=".acl" ng-show="streamId !== '$all'">Edit ACL</a>
         </li>
         <li class="page-nav__item">
             <a ui-sref=".addStreamEvent" ng-show="streamId.indexOf('$') !== 0">Add Event</a>

--- a/src/js/modules/streams/views/streams.list.tpl.html
+++ b/src/js/modules/streams/views/streams.list.tpl.html
@@ -13,7 +13,7 @@
 		</li>
 	</ul>
 </header>
-<div ng-if="isAdmin" class="container">
+<div class="container">
 	<div class="container-left">
 		<table>
 			<thead>
@@ -59,4 +59,3 @@
 		</table>
 	</div>
 </div>
-<em ng-if="!isAdmin">You must be an admin to view recently created streams</em>

--- a/src/js/modules/streams/views/streams.list.tpl.html
+++ b/src/js/modules/streams/views/streams.list.tpl.html
@@ -30,7 +30,7 @@
 				</tr>
 				<tr ng-hide="createdStreams">
 					<td>
-						<em>No recently created streams</em>
+						<em>{{noCreatedStreamsText}}</em>
 					</td>
 				</tr>
 
@@ -52,7 +52,7 @@
 				</tr>
 				<tr ng-hide="changedStreams">
 					<td>
-					<em>No recently changed streams</em>
+					<em>{{noChangedStreamsText}}</em>
 					</td>
 				</tr>
 			</tbody>

--- a/src/js/modules/users/controllers/UsersItemDeleteCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemDeleteCtrl.js
@@ -14,18 +14,22 @@ define(['./_module'], function (app) {
 				userService.remove($scope.user.loginName).then(function () {
 					msg.success('User deleted');
 					$state.go('users.list');
-				}, function () {
-					msg.failure('User was not deleted');
+				}, function (error) {
+					msg.failure('Failed to delete user: ' + error.message);
 				});
 			};
 
 			userService.get($stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
 				$scope.disable = false;
-			})
-			.error(function () {
-				msg.failure('User does not exists or you do not have permissions');
+			}, function (error) {
+				if(error.statusCode === 404){
+					msg.failure('User does not exist');
+				} else{
+					msg.failure('Failed to get user: ' + error.message);
+				}
 				$state.go('users');
 			});
 		}

--- a/src/js/modules/users/controllers/UsersItemDetailsCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemDetailsCtrl.js
@@ -3,17 +3,17 @@ define(['./_module'], function (app) {
     'use strict';
 
     return app.controller('UsersItemDetailsCtrl', [
-		'$scope', '$state', '$stateParams', 'UserService',
-		function ($scope, $state, $stateParams, userService) {
+		'$scope', '$state', '$stateParams', 'UserService', 'MessageService',
+		function ($scope, $state, $stateParams, userService, msg) {
 			
 			userService.get($stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
-			})
-			.error(function () { 
+			}, function (error) {
+				msg.failure('Failed to get user: ' + error.message);
 				$state.go('users');
 			});
-
 		}
 	]);
 });

--- a/src/js/modules/users/controllers/UsersItemDisableCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemDisableCtrl.js
@@ -12,26 +12,29 @@ define(['./_module'], function (app) {
 				$event.stopPropagation();
 
 				userService.disable($scope.user.loginName)
-				.success(function () {
+				.then(function () {
 					msg.success('User disabled');
 					$scope.$state.go('^.details');
-				})
-				.error(function (response) {
-					msg.failure('Failed to disable user, reason : ' + response.error);
+				}, function (error) {
+					msg.failure('Failed to disable user: ' + error.message);
 				});
 			};
 
 			userService.get($stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
 				$scope.disable = false;
 				if($scope.user.disabled) {
 					msg.warn('User already disabled');
 					$state.go('^.details');
 				}
-			})
-			.error(function () {
-				msg.failure('User does not exist or you do not have permissions');
+			}, function (error) {
+				if(error.statusCode === 404){
+					msg.failure('User does not exist');
+				} else{
+					msg.failure('Failed to get user: ' + error.message);
+				}
 				$state.go('users');
 			});
 		}

--- a/src/js/modules/users/controllers/UsersItemEditCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemEditCtrl.js
@@ -13,23 +13,26 @@ define(['./_module'], function (app) {
 				}
 				userService.update($scope.user.loginName, 
 					$scope.fullName, $scope.user.role)
-				.success(function () {
+				.then(function () {
 					msg.success('user updated');
 					$state.go('^.details');
-				})
-				.error(function () {
-					msg.failure('user not updated');
+				}, function (error) {
+					msg.failure('Failed to update user: ' + error.message);
 				});
 			};
 
 			userService.get($stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
 				$scope.user.role = data.data.groups[0];
 				$scope.fullName = $scope.user.fullName;
-			})
-			.error(function () {
-				msg.failure('user does not exists or you do not have perms');
+			}, function (error) {
+				if(error.statusCode === 404){
+					msg.failure('User does not exist');
+				} else{
+					msg.failure('Failed to get user: ' + error.message);
+				}
 				$state.go('users');
 			});
 		}

--- a/src/js/modules/users/controllers/UsersItemEnableCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemEnableCtrl.js
@@ -12,17 +12,17 @@ define(['./_module'], function (app) {
 				$event.stopPropagation();
 
 				userService.enable($scope.user.loginName)
-				.success(function () {
+				.then(function () {
 					msg.success('user enabled');
 					$state.go('^.details');
-				})
-				.error(function () {
-					msg.failure('user not enabled');
+				}, function (error) {
+					msg.failure('Failed to enable user: ' + error.message);
 				});
 			};
 
 			userService.get($stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
 				$scope.disable = false;
 
@@ -30,9 +30,12 @@ define(['./_module'], function (app) {
 					msg.warn('user already enabled');
 					$state.go('^.details');
 				}
-			})
-			.error(function () {
-				msg.failure('user does not exists or you do not have perms');
+			}, function (error) {
+				if(error.statusCode === 404){
+					msg.failure('User does not exist');
+				} else{
+					msg.failure('Failed to get user: ' + error.message);
+				}
 				$state.go('users');
 			});
 		}

--- a/src/js/modules/users/controllers/UsersItemResetCtrl.js
+++ b/src/js/modules/users/controllers/UsersItemResetCtrl.js
@@ -13,7 +13,7 @@ define(['./_module'], function (app) {
 				}
 
 				userService.resetPassword($scope.user.loginName, $scope.password)
-				.success(function () {
+				.then(function () {
 					msg.success('Password has been reset');
 					authService.resetCredentials($scope.user.loginName, $scope.password)
 					.then(function(){
@@ -22,18 +22,21 @@ define(['./_module'], function (app) {
 						msg.failure('We tried to reset the credentials in the cookie and failed. Please log in again.');
 						$state.go('signin');
 					});
-				})
-				.error(function () {
-					msg.failure('Password not reset');
+				}, function (error) {
+					msg.failure('Failed to reset password: ' + error.message);
 				});
 			};
 
 			userService.get($scope.$stateParams.username)
-			.success(function (data) {
+			.then(function (res) {
+				var data = res.data;
 				$scope.user = data.data;
-			})
-			.error(function () {
-				msg.failure('User does not exist or you do not have permission');
+			}, function (error) {
+				if(error.statusCode === 404){
+					msg.failure('User does not exist');
+				} else{
+					msg.failure('Failed to get user: ' + error.message);
+				}
 				$state.go('users');
 			});
 		}

--- a/src/js/modules/users/controllers/UsersListCtrl.js
+++ b/src/js/modules/users/controllers/UsersListCtrl.js
@@ -23,9 +23,9 @@ define(['./_module'], function (app) {
 				$scope.users = data.data;
 			});
 
-			all.promise.catch(function () {
+			all.promise.catch(function (error) {
 				all.stop();
-				msg.failure('Cannot get list of users');
+				msg.failure('Failed to retrieve list of users: ' + error.message);
 			});
 
 

--- a/src/js/modules/users/controllers/UsersNewCtrl.js
+++ b/src/js/modules/users/controllers/UsersNewCtrl.js
@@ -13,12 +13,11 @@ define(['./_module'], function (app) {
 					return;
 				}
 				userService.create($scope.newUser)
-				.success(function () {
+				.then(function () {
 					msg.success('User created');
 					$state.go('^.list');
-				})
-				.error(function (response) {
-					msg.failure('Failed to create user, reason : ' + response.error);
+				}, function (error) {
+					msg.failure('Failed to create user: ' + error.message);
 				});
 			};
 		}

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -23,7 +23,8 @@ define(['es-ui'], function (app) {
             authService.loadCredentials();
 
             infoService.getInfo()
-            .success(function(info){
+            .then(function(res){
+                var info = res.data;
                 $rootScope.esVersion = info.esVersion || '0.0.0.0';
                 $rootScope.esVersion = $rootScope.esVersion  === '0.0.0.0' ? 'development build' : $rootScope.esVersion;
                 $rootScope.projectionsEnabled = info.features.projections === true;
@@ -64,9 +65,8 @@ define(['es-ui'], function (app) {
                         $state.go('signin');
                     }
                 });
-            })
-			.error(function(){
-                msg.failure('Could not load /info endpoint');
+            }, function(error){
+                msg.failure('Failed to load /info endpoint: ' + error.message);
                 authService.clearCredentials();
             });
             
@@ -79,6 +79,11 @@ define(['es-ui'], function (app) {
                             $rootScope.singleNode = false;
                         }
                     }
+                }, function(error){
+                    if(error.statusCode === 401){
+                        return;
+                    }
+                    msg.failure('Failed to load options: ' + error.message);
                 });
             }
 

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -71,17 +71,15 @@ define(['es-ui'], function (app) {
             });
             
             function setSingleNodeOrCluster(){
-                if($rootScope.isAdminOrOps) {
-                    scavengeNotificationService.start();
-                    infoService.getOptions().then(function onGetOptions(response){
-                        var options = response.data;
-                        for (var index in options) {
-                            if(options[index].name === 'ClusterSize' && options[index].value > 1){
-                                $rootScope.singleNode = false;
-                            }
+                scavengeNotificationService.start();
+                infoService.getOptions().then(function onGetOptions(response){
+                    var options = response.data;
+                    for (var index in options) {
+                        if(options[index].name === 'ClusterSize' && options[index].value > 1){
+                            $rootScope.singleNode = false;
                         }
-                    });
-                }
+                    }
+                });
             }
 
 			function redirectAfterLoggingIn() {

--- a/src/js/services/AuthService.js
+++ b/src/js/services/AuthService.js
@@ -46,27 +46,15 @@ define(['./_module'], function (app) {
 	            $cookieStore.remove('es-creds');
 			}
 
-			function addCredentialsToCookie(username, password, groups){
+			function addCredentialsToCookie(username, password){
 				var escreds = $cookieStore.get('es-creds');
 				if(!escreds){
 					escreds = {};
 				}
 				escreds = {
-					credentials : Base64.encode(username + ':' + password),
-					groups : groups
+					credentials : Base64.encode(username + ':' + password)
 				};
 				$cookieStore.put('es-creds', escreds);
-			}
-
-			function setUserRole(groups) {
-				$rootScope.isAdmin = false;
-				$rootScope.isOps = false;
-				if(groups && groups.length > 0)
-				{
-					$rootScope.isAdmin = groups.indexOf('$admins') > -1;
-					$rootScope.isOps = groups.indexOf('$ops') > -1;
-				}
-				$rootScope.isAdminOrOps = $rootScope.isAdmin || $rootScope.isOps;
 			}
 
 			var escreds = getCredentialsFromCookie();
@@ -75,13 +63,12 @@ define(['./_module'], function (app) {
 			}
 
 		    return {
-		        setCredentials: function (username, password, groups) {
+		        setCredentials: function (username, password) {
 		            var credentials = Base64.encode(username + ':' + password);
 		            
 		            $http.defaults.headers.common.Authorization = 'Basic ' + credentials;
 
-					setUserRole(groups);
-		            addCredentialsToCookie(username, password, groups);
+		            addCredentialsToCookie(username, password);
 				},
 				loadCredentials: function(){
 					var credentials = getCredentialsFromCookie();
@@ -97,7 +84,6 @@ define(['./_module'], function (app) {
 					var deferred = $q.defer();
 					
 					if($rootScope.authentication.type === 'insecure'){
-						setUserRole(['$admins']);
 						deferred.resolve();
 					}
 					else if($rootScope.authentication.type === 'oauth'){
@@ -117,8 +103,6 @@ define(['./_module'], function (app) {
 							var parts = Base64.decode(credentials).split(':');
 							this.validate(parts[0], parts[1])
 							.success(function() {
-								var groups = getGroupsFromCookie();
-								setUserRole(groups);
 								deferred.resolve();
 							})
 							.error(function (){
@@ -155,14 +139,6 @@ define(['./_module'], function (app) {
 		        			Authorization: 'Basic ' + credentials
 		        		}
 		        	});
-		        },
-		        getUserGroups: function(username) {
-		        	var deferred = $q.defer();
-					$http.get(urlBuilder.build(urls.admin.login, username)).success(function(userInfo) {
-		            	var groups = userInfo.data.groups;
-		            	deferred.resolve(groups);
-	            	});
-	            	return deferred.promise;
 		        }
 		    };
 		}

--- a/src/js/services/Poller.js
+++ b/src/js/services/Poller.js
@@ -40,8 +40,8 @@ define(['./_module'], function (app) {
 						.then(function (data) {
 							self.intervalId = $timeout(tick, self.opts.interval);
 							self.deferred.notify(data.data);
-						}, function () {
-							self.deferred.reject('Error occured');
+						}, function (error) {
+							self.deferred.reject(error);
 						});
 					})();
 				},

--- a/src/js/services/ScavengeNotificationService.js
+++ b/src/js/services/ScavengeNotificationService.js
@@ -39,13 +39,25 @@ define(['./_module'], function (app) {
 								$timeout(function() {
 									tick();
 								}, constants.scavengeStatus.pollInterval);
+							}, function(error){
+								if(error.statusCode === 401){
+									return;
+								} else{
+									msg.failure('Failed to retrieve last scavenge status: ' + error.message);
+								}
 							});
 						};
 						tick();
-					}, function() {
-						$timeout(function() {
-						start();
-					}, constants.scavengeStatus.pollInterval);
+					}, function(error) {
+						if(error.statusCode === 401){
+							return;
+						} else if(error.statusCode === 404){
+							$timeout(function() {
+								start();
+							}, constants.scavengeStatus.pollInterval);
+						} else {
+							msg.failure('Failed to retrieve last scavenge status: ' + error.message);
+						}
 				});
 			}
 			return {

--- a/src/views/index.tpl.html
+++ b/src/views/index.tpl.html
@@ -15,20 +15,20 @@
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('streams') }" title="{{!streamsBrowserEnabled ? atomDisabledMessage : ''}}">
 				<a ng-class="{'disabled':!streamsBrowserEnabled}" ui-sref="streams.list">Stream Browser</a>
 			</li>
-			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('projections') }" title="{{!isAdminOrOps ? notAdminOrOpsMessage : !projectionsEnabled ? projectionsNotRunningMessage : ''}}">
+			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('projections') }" title="{{!projectionsEnabled ? projectionsNotRunningMessage : ''}}">
 				<a ng-class="{'disabled': !projectionsEnabled}" ui-sref="projections.list">Projections</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('query') }" title="{{!projectionsEnabled ? projectionsNotRunningMessage : ''}}">
 				<a ng-class="{'disabled':!projectionsEnabled}" ui-sref="query">Query</a>
 			</li>
-			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('competing') }" title="{{!isAdminOrOps ? notAdminOrOpsMessage : ''}}">
+			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('competing') }">
 				<a ui-sref="subscriptions.list">Persistent Subscriptions</a>
 			</li>
-			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('admin') }" title="{{!isAdminOrOps ? notAdminOrOpsMessage : ''}}">
-				<a ng-class="{'disabled': !isAdminOrOps}" ui-sref="admin">Admin</a>
+			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('admin') }">
+				<a ui-sref="admin">Admin</a>
 			</li>
-			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('users') }" title="{{!isAdmin ? notAdminMessage : ''}}">
-				<a ng-class="{'disabled': !isAdmin || !userManagementEnabled}" ui-sref="users.list">Users</a>
+			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('users') }">
+				<a ng-class="{'disabled': !userManagementEnabled}" ui-sref="users.list">Users</a>
 			</li>
 			<li class="site-nav__item" ng-class="{'site-nav__item--active': $state.includes('signout') }">
 				<a ng-class="{'disabled': !logoutEnabled}" ui-sref="signout">{{ logoutButtonText }}</a>


### PR DESCRIPTION
Fixes #267 

The PR removes the concept of "role" from the UI which is not compatible with an external policy engine used for authorization.

Now, all users will see the same UI but appropriate error messages will be displayed when attempting to do an unauthorized operation.

The PR affects most of the interactions done between the browser and server (due to the $http interceptor). Other small bugs have also been fixed along the way.

Notes:  
- This PR needs to wait for the branch `multi-auth` (PR #266) to be merged so that this PR is re-targeted to master.