### PR TITLE
Use state instead of passing the code challenge correlation ID parameter to the redirect URI

### DIFF
--- a/src/js/run.js
+++ b/src/js/run.js
@@ -51,9 +51,12 @@ define(['es-ui'], function (app) {
                         .then(function(res){
                             var codeChallenge = res.data.code_challenge;
                             var codeChallengeMethod = res.data.code_challenge_method;
-                            var codeChallengeCorrelationId = res.data.code_challenge_correlation_id;
-                            var redirectUri = encodeURIComponent($rootScope.baseUrl + $rootScope.authentication.properties.redirect_uri + '?code_challenge_correlation_id=' + codeChallengeCorrelationId);
-                            var authorizationUri = authorizationEndpoint + '?response_type=' + responseType + '&client_id=' + clientId + '&redirect_uri=' + redirectUri + '&scope=' + scope + '&code_challenge=' + codeChallenge + '&code_challenge_method=' + codeChallengeMethod;
+                            var state = {
+                                'code_challenge_correlation_id': res.data.code_challenge_correlation_id
+                            };
+                            state = btoa(JSON.stringify(state));
+                            var redirectUri = encodeURIComponent($rootScope.baseUrl + $rootScope.authentication.properties.redirect_uri);
+                            var authorizationUri = authorizationEndpoint + '?response_type=' + responseType + '&client_id=' + clientId + '&redirect_uri=' + redirectUri + '&scope=' + scope + '&code_challenge=' + codeChallenge + '&code_challenge_method=' + codeChallengeMethod + '&state=' + state;
                             window.location.href = authorizationUri;
                         },
                         function(){


### PR DESCRIPTION
The OAuth 2.0 specs say that any local state should be passed in via the `state` parameter. We were previously passing the code challenge correlation ID parameter directly in the redirect URI but some identity providers (like Google accounts) do not allow any additional parameter in the callback and will show an error that the redirect URI does not match with the whitelisted redirect URIs.

Related server-side PR: https://github.com/EventStore/EventStore.CommercialHA/pull/159
Note: This PR merges into `multi-auth` branch