### PR TITLE
Don't poll for scavenges

### DIFF
--- a/src/js/modules/security/controllers/SignInCtrl.js
+++ b/src/js/modules/security/controllers/SignInCtrl.js
@@ -3,8 +3,8 @@ define(['./_module'], function (app) {
     'use strict';
 
     return app.controller('SignInCtrl', [
-		'$scope', '$rootScope', '$state', '$location', 'AuthService', 'MessageService', 'InfoService', 'ScavengeNotificationService',
-		function ($scope, $rootScope, $state, $location, authService, msg, infoService, scavengeNotificationService) {
+		'$scope', '$rootScope', '$state', '$location', 'AuthService', 'MessageService', 'InfoService',
+		function ($scope, $rootScope, $state, $location, authService, msg, infoService) {
 
 			$scope.log = {
 				username: '',
@@ -33,7 +33,6 @@ define(['./_module'], function (app) {
 			};
 
 			function setSingleNodeOrCluster(){
-				scavengeNotificationService.start();
 				infoService.getOptions().then(function(res){
 					var options = res.data;
 					for (var index in options) {

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -8,8 +8,8 @@ define(['es-ui'], function (app) {
         });
     }]);
 	return app.run([
-        '$rootScope', '$location', '$state', '$stateParams', 'AuthService', 'InfoService', 'ScavengeNotificationService', 'MessageService','$http',
-        function ($rootScope, $location, $state, $stateParams, authService, infoService, scavengeNotificationService, msg, $http) {
+        '$rootScope', '$location', '$state', '$stateParams', 'AuthService', 'InfoService', 'MessageService','$http',
+        function ($rootScope, $location, $state, $stateParams, authService, infoService, msg, $http) {
             $rootScope.baseUrl = $location.protocol() + '://' + $location.host() + ':' + $location.port();
             /*$rootScope.baseUrl = 'https://127.0.0.1:2113'; //uncomment during development*/
             $rootScope.projectionsEnabled = false;
@@ -77,7 +77,6 @@ define(['es-ui'], function (app) {
             });
             
             function setSingleNodeOrCluster(){
-                scavengeNotificationService.start();
                 infoService.getOptions().then(function onGetOptions(response){
                     var options = response.data;
                     for (var index in options) {


### PR DESCRIPTION
 - Remove scavengeNotificationService from Run and logIn controllers so that the UI no longer polls for scavenge status. This prevents the 404 messages that show up in the UI if a scavenge has not been run.
- If a 404 is received on the admin screen, stop the scavenge status poller.
- Trigger the scavenge status poller if the scavenge button is clicked. This will allow the UI to update the scavenge status once a scavenge has been triggered.
- If a scavenge was triggered any other way (through curl for example), the UI will need to be refreshed to see status updates.