### PR TITLE
Fix off by one error in behind message count in persistent subscriptions

### DIFF
--- a/src/js/modules/competing/services/SubscriptionsMapper.js
+++ b/src/js/modules/competing/services/SubscriptionsMapper.js
@@ -108,7 +108,7 @@ define(['./_module'], function (app) {
 					current.behindByTime = undefined;
 					current.behindStatus = '';
 				} else {
-					current.behindByMessages = (current.lastKnownEventPosition - current.lastCheckpointedEventPosition);
+					current.behindByMessages = (current.lastKnownEventPosition - current.lastCheckpointedEventPosition) + 1;
 					current.behindByTime = Math.round((current.behindByMessages / current.averageItemsPerSecond) * 100)/100;
 					current.behindByTime = isFinite(current.behindByTime) ? current.behindByTime : 0;
 					current.behindStatus = current.behindByMessages + ' / ' + current.behindByTime;


### PR DESCRIPTION
Fixes https://github.com/EventStore/EventStore.UI/issues/319

The number of messages required to be processed by a persistent subscription to stream to catchup is off by one.
This was introduced in commit: https://github.com/EventStore/EventStore.UI/commit/26d9cf5dd15ff86c1939c62ef3b35a24d4bb1b56