### PR TITLE
Configure NodeJS to use python2 for the GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '2.7.18'
       - name: Setup node
         uses: actions/setup-node@v1
         with:
           node-version: 10
       - name: Packaging
         run: |
+          npm config set python2 python
           npm install bower@~1.8.4 -g
           bower install
           npm install gulp@~3.8.8 -g

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '2.7.18'
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -21,6 +24,7 @@ jobs:
           build-type: nightly
       - name: Packaging
         run: |
+          npm config set python2 python
           npm install bower@~1.8.4 -g
           bower install
           npm install gulp@~3.8.8 -g

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '2.7.18'
       - name: Get the version
         id: get_version
         run: echo ::set-output name=version::${GITHUB_REF:15}
@@ -26,6 +29,7 @@ jobs:
           version: oss-v${{ steps.get_version.outputs.version }}
       - name: Packaging
         run: |
+          npm config set python2 python
           npm install bower@~1.8.4 -g
           bower install --allow-root
           npm install gulp@~3.8.8 -g


### PR DESCRIPTION
This prevents the Packaging step for the 'Build UI' job from failing when NodeJS v16+ is used.