### PR TITLE
Stop using deprecated way of setting workflow output (DB-84)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF:15}
+        run: echo "version=${GITHUB_REF:15}" >> $GITHUB_OUTPUT
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Changed: Use `$GITHUB_OUTPUT` for workflow output.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/