### PR TITLE
Fix using deprecated GHA runner (DB-124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build UI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   package:
     name: Package UI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   package:
     name: Package OSS UI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixed: Build not running because of deprecated `ubuntu-18.04` runner.