### PR TITLE
Incorrect number of behind messages in persistent subscriptions dashboard [DB-116]

### DIFF
--- a/src/js/modules/competing/services/SubscriptionsMapper.js
+++ b/src/js/modules/competing/services/SubscriptionsMapper.js
@@ -108,7 +108,11 @@ define(['./_module'], function (app) {
 					current.behindByTime = undefined;
 					current.behindStatus = '';
 				} else {
-					current.behindByMessages = (current.lastKnownEventPosition - current.lastCheckpointedEventPosition) + 1;
+					if (current.lastKnownEventPosition == null) {
+						current.behindByMessages = 0;
+					} else {
+						current.behindByMessages = (current.lastKnownEventPosition - current.lastCheckpointedEventPosition) + 1;
+					}
 					current.behindByTime = Math.round((current.behindByMessages / current.averageItemsPerSecond) * 100)/100;
 					current.behindByTime = isFinite(current.behindByTime) ? current.behindByTime : 0;
 					current.behindStatus = current.behindByMessages + ' / ' + current.behindByTime;


### PR DESCRIPTION
Fixed: Incorrect number of behind messages in persistent subscrptions dashboard.

Fixes https://github.com/EventStore/EventStore.UI/issues/336

Currently # of messages in persistent subscription dashboard is showing 1 / 0 (behind messages) even the stream does not exists. The goal of this PR to fix the incorrect number of behind messages.