### PR TITLE
Use improved and supported asset uploader (DB-308)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,11 +30,11 @@ jobs:
           zip -r EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip clusternode-web
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        uses: softprops/action-gh-release@v1
         with:
-           upload_url: ${{ steps.release.outputs.upload_url }}
-           asset_path: ./EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip
-           asset_name: EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip
-           asset_content_type: application/zip
+          tag_name: nightly-build
+          draft: false
+          prerelease: true
+          token: ${{ secrets.GH_PAT }}
+          files: |
+            ./EventStore.OSS.UI-v${{ steps.release.outputs.version}}.zip


### PR DESCRIPTION
Changed: Use improved and supported release asset uploader.

We occasionally have failing nightly builds caused by the `EventStore.UI` nightly release not being properly linked to the nightly tag, instead it's linked to `untagged-73fb15d9d4098dc463d3`. Because of this the nightly build can't retrieve the nightly UI release by tag name and fails on this.