### PR TITLE
small promise fix, was not marked as resolved correctly

### DIFF
--- a/src/js/services/Poller.js
+++ b/src/js/services/Poller.js
@@ -40,6 +40,7 @@ define(['./_module'], function (app) {
 						.then(function (data) {
 							self.intervalId = $timeout(tick, self.opts.interval);
 							self.deferred.notify(data.data);
+							self.deferred.resolve();
 						}, function (error) {
 							self.deferred.reject(error);
 						});


### PR DESCRIPTION
Fixes: calling tick() too many times
This is related to the UI requesting $mem-gossip and $mem-node-state multiple times https://github.com/EventStore/EventStore/pull/4123
it looks like a small change but this should be tested thoroughly as it affects the Poller which is used in many places